### PR TITLE
Install stylelint-config-concentric-order

### DIFF
--- a/ngx-fudis/.stylelintrc.json
+++ b/ngx-fudis/.stylelintrc.json
@@ -2,12 +2,14 @@
 	"extends": [
 		"stylelint-config-standard-scss",
 		"stylelint-config-sass-guidelines",
+		"stylelint-config-concentric-order",
 		"stylelint-config-prettier-scss"
 	],
 	"ignoreFiles": [
 		"dist/**/*.scss"
 	],
 	"rules": {
+		"order/properties-alphabetical-order": null,
 		"color-no-hex": true,
 		"color-hex-length": "long",
 		"unit-disallowed-list": [

--- a/ngx-fudis/package-lock.json
+++ b/ngx-fudis/package-lock.json
@@ -60,6 +60,7 @@
 				"ng-packagr": "^13.0.0",
 				"prettier": "2.7.1",
 				"stylelint": "^14.15.0",
+				"stylelint-config-concentric-order": "^5.1.0",
 				"stylelint-config-prettier-scss": "^0.0.1",
 				"stylelint-config-sass-guidelines": "^9.0.1",
 				"stylelint-config-standard-scss": "^6.1.0",
@@ -31248,6 +31249,15 @@
 				"url": "https://opencollective.com/stylelint"
 			}
 		},
+		"node_modules/stylelint-config-concentric-order": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-concentric-order/-/stylelint-config-concentric-order-5.1.0.tgz",
+			"integrity": "sha512-+JEz/qSO/YBeegKtf25b3A1/7/pFRNiBCLAyrMkcwSJf2QKeBHJ5qm0FFKK0+5Os/wC+dKpmBPk0BOkQu+y8Zw==",
+			"dev": true,
+			"dependencies": {
+				"stylelint-order": "^5.0.0"
+			}
+		},
 		"node_modules/stylelint-config-prettier": {
 			"version": "9.0.4",
 			"resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.4.tgz",
@@ -58427,6 +58437,15 @@
 					"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
 					"dev": true
 				}
+			}
+		},
+		"stylelint-config-concentric-order": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-concentric-order/-/stylelint-config-concentric-order-5.1.0.tgz",
+			"integrity": "sha512-+JEz/qSO/YBeegKtf25b3A1/7/pFRNiBCLAyrMkcwSJf2QKeBHJ5qm0FFKK0+5Os/wC+dKpmBPk0BOkQu+y8Zw==",
+			"dev": true,
+			"requires": {
+				"stylelint-order": "^5.0.0"
 			}
 		},
 		"stylelint-config-prettier": {

--- a/ngx-fudis/package.json
+++ b/ngx-fudis/package.json
@@ -67,6 +67,7 @@
 		"ng-packagr": "^13.0.0",
 		"prettier": "2.7.1",
 		"stylelint": "^14.15.0",
+		"stylelint-config-concentric-order": "^5.1.0",
 		"stylelint-config-prettier-scss": "^0.0.1",
 		"stylelint-config-sass-guidelines": "^9.0.1",
 		"stylelint-config-standard-scss": "^6.1.0",

--- a/ngx-fudis/projects/dev/src/app/app.scss
+++ b/ngx-fudis/projects/dev/src/app/app.scss
@@ -3,8 +3,8 @@
 /* stylelint-disable selector-class-pattern */
 /* stylelint-disable unit-disallowed-list */
 .basic-flex-box {
-	border: 2px solid orange;
 	display: flex;
 	flex-direction: column;
+	border: 2px solid orange;
 	max-width: 40rem;
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.scss
@@ -11,12 +11,19 @@
 	@include typography.fudis-button-typography;
 	@include borders.fudis-border('2px', 'solid', 'primary');
 
-	cursor: pointer;
 	display: inline-block;
+	cursor: pointer;
 	padding: 0 spacing.$fudis-spacing-xs;		
 
 	&:focus {
 		@include focus.fudis-focus-generic;
+	}
+
+	&:disabled {
+		@include colors.fudis-text-color('gray-dark');
+		@include colors.fudis-bg-color('gray-light');
+		@include borders.fudis-border('2px', 'solid', 'transparent');
+		@include borders.fudis-outline('1px', 'dashed', 'gray-middle');
 	}
 
 	&__primary {
@@ -40,12 +47,5 @@
 
 	&__medium {
 		height: spacing.$fudis-spacing-l;
-	}
-
-	&:disabled {
-		@include colors.fudis-text-color('gray-dark');
-		@include colors.fudis-bg-color('gray-light');
-		@include borders.fudis-border('2px', 'solid', 'transparent');
-		@include borders.fudis-outline('1px', 'dashed', 'gray-middle');
 	}
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/fudis-text-input/text-input.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/fudis-text-input/text-input.component.scss
@@ -19,9 +19,9 @@
 		@include borders.fudis-border-radius('2px');
 
 		box-sizing: border-box;
-		height: spacing.$fudis-spacing-l;
 		padding: spacing.$fudis-spacing-xxs spacing.$fudis-spacing-s;
 		width: 100%;
+		height: spacing.$fudis-spacing-l;
 
 		&:focus {
 			@include focus.fudis-focus-form-field;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/foundations/focus/mixins.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/foundations/focus/mixins.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable property-disallowed-list */
 @use '../spacing/tokens.scss' as spacing;
 @use '../borders/mixins.scss' as borders;
 @import './tokens';
@@ -5,17 +6,15 @@
 
 
 @mixin fudis-focus-generic {
-  box-shadow: 0 0 0 spacing.$fudis-spacing-xxs $fudis-white;
-	/* stylelint-disable-next-line property-disallowed-list */
 	outline: $fudis-focus-generic-outline;
   outline-offset: spacing.$fudis-pixel-1;
+  box-shadow: 0 0 0 spacing.$fudis-spacing-xxs $fudis-white;
 }
 
 @mixin fudis-focus-form-field {
 	@include borders.fudis-border('1px', 'solid', 'primary');
 
-  box-shadow: 0 0 0 spacing.$fudis-pixel-1 $fudis-white;
-  /* stylelint-disable-next-line property-disallowed-list */
   outline: $fudis-focus-form-field-outline;
   outline-offset: -(spacing.$fudis-pixel-2);
+  box-shadow: 0 0 0 spacing.$fudis-pixel-1 $fudis-white;
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/foundations/typography/fonts.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/foundations/typography/fonts.scss
@@ -1,34 +1,33 @@
-/* stylelint-disable order/properties-alphabetical-order */
 /* stylelint-disable property-disallowed-list */
 
 // Light, 300 
 @font-face {
-  font-family: 'Fira Sans';
-  src: url('./../../assets/fonts/fira/woff2/FiraSans-Light.woff2');
-  font-style: normal;
+	font-family: 'Fira Sans';
+	src: url('./../../assets/fonts/fira/woff2/FiraSans-Light.woff2');
   font-weight: 300;
+  font-style: normal;
 }
 
 // Regular, 400 
 @font-face {
-  font-family: 'Fira Sans';
+	font-family: 'Fira Sans';
   src: url('./../../assets/fonts/fira/woff2/FiraSans-Regular.woff2');
-  font-style: normal;
   font-weight: 400;
+  font-style: normal;
 }
 
 // Medium, 500 
 @font-face {
-  font-family: 'Fira Sans';
+	font-family: 'Fira Sans';
   src: url('./../../assets/fonts/fira/woff2/FiraSans-Medium.woff2');
-  font-style: normal;
   font-weight: 500;
+  font-style: normal;
 }
 
 // Semibold, 600 
 @font-face {
   font-family: 'Fira Sans';
   src: url('./../../assets/fonts/fira/woff2/FiraSans-SemiBold.woff2');
-  font-style: normal;
   font-weight: 600;
+  font-style: normal;
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/foundations/typography/mixins.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/foundations/typography/mixins.scss
@@ -8,127 +8,127 @@
 // Body Text
 
 @mixin fudis-body-l-light {
+  margin-bottom: spacing.$fudis-spacing-l;
+  line-height: tokens.$fudis-body-l-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-body-l-font-size;
   font-weight: tokens.$fudis-light;
-  line-height: tokens.$fudis-body-l-line-height;
-  margin-bottom: spacing.$fudis-spacing-l;
 }
 
 @mixin fudis-body-l-regular {
+  margin-bottom: spacing.$fudis-spacing-l;
+  line-height: tokens.$fudis-body-l-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-body-l-font-size;
   font-weight: tokens.$fudis-regular;
-  line-height: tokens.$fudis-body-l-line-height;
-  margin-bottom: spacing.$fudis-spacing-l;
 }
 
 @mixin fudis-body-m-light {
+  margin-bottom: spacing.$fudis-spacing-m;
+  line-height: tokens.$fudis-body-m-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-body-m-font-size;
   font-weight: tokens.$fudis-light;
-  line-height: tokens.$fudis-body-m-line-height;
-  margin-bottom: spacing.$fudis-spacing-m;
 }
 
 @mixin fudis-body-m-regular {
+  margin-bottom: spacing.$fudis-spacing-m;
+  line-height: tokens.$fudis-body-m-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-body-m-font-size;
   font-weight: tokens.$fudis-regular;
-  line-height: tokens.$fudis-body-m-line-height;
-  margin-bottom: spacing.$fudis-spacing-m;
 }
 
 @mixin fudis-body-s-regular {
+  line-height: tokens.$fudis-body-s-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-body-s-font-size;
   font-weight: tokens.$fudis-regular;
-  line-height: tokens.$fudis-body-s-line-height;
 }
 
 // Headings
 
 @mixin fudis-heading-xxl {
+  margin-bottom: spacing.$fudis-spacing-s;
+  line-height: tokens.$fudis-heading-l-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-heading-xxl-font-size;
   font-weight: tokens.$fudis-medium;
-  line-height: tokens.$fudis-heading-l-line-height;
-  margin-bottom: spacing.$fudis-spacing-s;
 }
 
 @mixin fudis-heading-xl {
+  margin-bottom: spacing.$fudis-spacing-s;
+  line-height: tokens.$fudis-heading-l-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-heading-xl-font-size;
   font-weight: tokens.$fudis-medium;
-  line-height: tokens.$fudis-heading-l-line-height;
-  margin-bottom: spacing.$fudis-spacing-s;
 }
 
 @mixin fudis-heading-l {
+  margin-bottom: spacing.$fudis-spacing-xs;
+  line-height: tokens.$fudis-heading-m-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-heading-l-font-size;
   font-weight: tokens.$fudis-medium;
-  line-height: tokens.$fudis-heading-m-line-height;
-  margin-bottom: spacing.$fudis-spacing-xs;
 }
 
 @mixin fudis-heading-m {
+  margin-bottom: spacing.$fudis-spacing-xs;
+  line-height: tokens.$fudis-heading-m-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-heading-m-font-size;
   font-weight: tokens.$fudis-medium;
-  line-height: tokens.$fudis-heading-m-line-height;
-  margin-bottom: spacing.$fudis-spacing-xs;
 }
 
 @mixin fudis-heading-s {
+  margin-bottom: spacing.$fudis-spacing-xs;
+  line-height: tokens.$fudis-heading-s-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-heading-s-font-size;
   font-weight: tokens.$fudis-medium;
-  line-height: tokens.$fudis-heading-s-line-height;
-  margin-bottom: spacing.$fudis-spacing-xs;
 }
 
 @mixin fudis-heading-xs {
+  margin-bottom: spacing.$fudis-spacing-xs;
+  line-height: tokens.$fudis-heading-s-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-heading-xs-font-size;
   font-weight: tokens.$fudis-bold;
-  line-height: tokens.$fudis-heading-s-line-height;
-  margin-bottom: spacing.$fudis-spacing-xs;
 }
 
 @mixin fudis-heading-xxs {
+  margin-bottom: spacing.$fudis-spacing-xs;
+  line-height: tokens.$fudis-heading-s-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-heading-xxs-font-size;
   font-weight: tokens.$fudis-bold;
-  line-height: tokens.$fudis-heading-s-line-height;
-  margin-bottom: spacing.$fudis-spacing-xs;
 }
 
 // Other UI styles 
 
 @mixin fudis-text-field-label {
+  text-transform: tokens.$fudis-all-caps;
+	line-height: tokens.$fudis-text-input-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-body-m-font-size;
   font-weight: tokens.$fudis-regular;
-	line-height: tokens.$fudis-text-input-line-height;
-  text-transform: tokens.$fudis-all-caps;
 }
 
 @mixin fudis-text-field-input {
+	line-height: tokens.$fudis-text-input-line-height;
 	font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-body-l-font-size;
   font-weight: tokens.$fudis-light;
-	line-height: tokens.$fudis-text-input-line-height;
 }
 
 @mixin fudis-button-typography {
 	@include fudis-letter-spacing("1px");
 
+	text-transform: uppercase;
+	line-height: tokens.$fudis-body-s-line-height;
 	font-family: tokens.$fudis-font-family, 'Helvetica Neue', Helvetica, Arial, sans-serif;
 	font-size: tokens.$fudis-body-m-font-size;
 	font-weight: tokens.$fudis-bold;
-	line-height: tokens.$fudis-body-s-line-height;
-	text-transform: uppercase;
 }
 
 @mixin fudis-letter-spacing($width) {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/theme/ngMaterialCustomisation.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/theme/ngMaterialCustomisation.scss
@@ -8,8 +8,8 @@ mat-form-field {
 			}
 		
 			&-subscript-wrapper {
-				margin-top: 0;
 				position: relative;
+				margin-top: 0;
 			}
 		
 			&-infix {
@@ -20,16 +20,16 @@ mat-form-field {
 			}
 		
 			&-label-wrapper {
-				padding-top: 0;
 				position: relative;
+				padding-top: 0;
 			}
 		
 			&-label {
 				position: relative;
 				top: 0;
 				transform: none;
-				white-space: inherit;
 				width: 100%;
+				white-space: inherit;
 			}
 		}
 	}


### PR DESCRIPTION
Stylelint doesn't provide a way to define in which order CSS properties are listed and with guidelines plugin even forces alphabetical order. This plugin sets and lints the order in an opinionated "as it should be" order. 