### PR TITLE
Workaround for name issue with ng forms and radiobuttons

### DIFF
--- a/ngx-fudis/projects/dev/src/app/app.component.ts
+++ b/ngx-fudis/projects/dev/src/app/app.component.ts
@@ -45,11 +45,6 @@ import { Component } from '@angular/core';
 			<fudis-icon icon="chevron" rotate="cw-90"></fudis-icon>
 			<fudis-icon icon="achievement" color="success"></fudis-icon>
 		</div>
-		<fudis-radio-button-group label="Otsikko"></fudis-radio-button-group>
-		<!-- <form (FormGroup)="(frm)">
-			<fudis-radio-button id="muu" name="hedelmä" [value]="value" [control]="getRadioOptions()"></fudis-radio-button>
-			<fudis-radio-button id="maa" name="hedelmä" [value]="value" [control]="getRadioOptions()"></fudis-radio-button>
-		</form> -->
 		<!-- <div class="basic-flex-box2">
 			<fudis-badge variant="accent" content="accent"></fudis-badge>
 			<fudis-badge variant="danger">danger</fudis-badge>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.html
@@ -1,4 +1,4 @@
-<fieldset class="fudis-form-element fudis-radio-button-group">
+<fieldset [attr.aria-labelledby]="legendId" [id]="id" class="fudis-form-element fudis-radio-button-group">
 	<fudis-legend [attr.id]="legendId">{{ legend }}</fudis-legend>
 	<li class="fudis-radio-button-group__option" *ngFor="let option of options; let index = index">
 		<fudis-radio-button

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.ts
@@ -54,7 +54,7 @@ export class RadioButtonGroupComponent implements OnInit {
 
 		if (!namesAreIdentical) {
 			throw new Error(
-				`For radio button options for fudis-radio-button-group 'name' should be identical for all options.`
+				`From @Input array of options to fudis-radio-button-group value 'name' should be identical for all options.`
 			);
 		}
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button/radio-button.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button/radio-button.component.html
@@ -5,6 +5,7 @@
 		[attr.aria-describedby]="describedByLegend"
 		[id]="id"
 		[attr.name]="name"
+		[name]="name"
 		[formControl]="radioButtonFormControl"
 		[attr.required]="required"
 		[attr.disabled]="disabled"


### PR DESCRIPTION
https://github.com/angular/angular/issues/11757

Issue replication without this PR:
In storybook radiobutton example: tab from first group to the second group. Make a selection and then shift+tab to previous group, earlier it selected the last item and not the checked item.

Also added labelled-by attributes so screen reader reads the legend as well.