### PR TITLE
DS-79: Numerovalitsimen lisäys text-inputtiin + testien korjailuja

### DIFF
--- a/ngx-fudis/projects/dev/src/app/app.component.ts
+++ b/ngx-fudis/projects/dev/src/app/app.component.ts
@@ -8,12 +8,6 @@ import { Component } from '@angular/core';
 			<h1>Welcome to {{ title }}!</h1>
 		</div>
 		<form class="basic-flex-box">
-			<h2>Text input ja checbox</h2>
-			<fudis-text-input [required]="true" label="Fudis text input"></fudis-text-input>
-			<!-- <fudis-checkbox data-theme="sisu" label="Checkboxin label" [required]="true"></fudis-checkbox> -->
-			<fudis-text-input label="Fudis text input 2"></fudis-text-input>
-		</form>
-		<form class="basic-flex-box">
 			<h2>Textarea ja button</h2>
 			<fudis-text-area
 				label="Pakollinen textarea, tällä on myös aika pitkä label"
@@ -41,19 +35,6 @@ import { Component } from '@angular/core';
 				label="Single select"
 				helpText="Tästä pitäisi valita kiinnostavin kurssi, ole hyvä"></fudis-dropdown>
 		</form>
-		<div class="basic-flex-box2">
-			<fudis-icon icon="chevron" rotate="cw-90"></fudis-icon>
-			<fudis-icon icon="achievement" color="success"></fudis-icon>
-		</div>
-
-		<!-- <div class="basic-flex-box2">
-			<fudis-badge variant="accent" content="accent"></fudis-badge>
-			<fudis-badge variant="danger">danger</fudis-badge>
-			<fudis-badge data-theme="sisu" variant="primary" content="sisu primary"></fudis-badge>
-			<fudis-badge data-theme="into" variant="primary" content="into primary"></fudis-badge>
-			<fudis-badge variant="secondary" content="secondary"></fudis-badge>
-			<fudis-badge variant="success" content="success"></fudis-badge>
-		</div> -->
 	`,
 	styleUrls: ['./app.scss'],
 })

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/dropdown/dropdown.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/dropdown/dropdown.component.spec.ts
@@ -1,5 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { DropdownComponent } from './dropdown.component';
 
 describe('DropdownComponent', () => {
@@ -9,6 +12,7 @@ describe('DropdownComponent', () => {
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
 			declarations: [DropdownComponent],
+			imports: [ReactiveFormsModule, MatFormFieldModule, MatSelectModule, BrowserAnimationsModule],
 		}).compileComponents();
 	});
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { UntypedFormControl } from '@angular/forms';
+import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
 import { RadioButtonGroupComponent } from './radio-button-group.component';
 import { RadioButtonOption } from '../../../types/forms';
 
@@ -18,6 +18,7 @@ describe('RadioButtonGroupComponent', () => {
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
 			declarations: [RadioButtonGroupComponent],
+			imports: [ReactiveFormsModule],
 		}).compileComponents();
 	});
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { MockComponent } from 'ng-mocks';
-import { LegendComponent } from 'ngx-fudis';
+import { LegendComponent } from '../legend/legend.component';
 import { RadioButtonGroupComponent } from './radio-button-group.component';
 import { RadioButtonOption } from '../../../types/forms';
 import { RadioButtonComponent } from './radio-button/radio-button.component';

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.spec.ts
@@ -1,7 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { MockComponent } from 'ng-mocks';
+import { LegendComponent } from 'ngx-fudis';
 import { RadioButtonGroupComponent } from './radio-button-group.component';
 import { RadioButtonOption } from '../../../types/forms';
+import { RadioButtonComponent } from './radio-button/radio-button.component';
 
 const testFormControl: UntypedFormControl = new UntypedFormControl('capybara');
 
@@ -17,7 +21,7 @@ describe('RadioButtonGroupComponent', () => {
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
-			declarations: [RadioButtonGroupComponent],
+			declarations: [RadioButtonGroupComponent, MockComponent(LegendComponent), MockComponent(RadioButtonComponent)],
 			imports: [ReactiveFormsModule],
 		}).compileComponents();
 	});

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button/radio-button.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button/radio-button.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { UntypedFormControl } from '@angular/forms';
+import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
 import { RadioButtonComponent } from './radio-button.component';
 
 const lonelyFormControl = new UntypedFormControl();
@@ -12,6 +11,7 @@ describe('RadioButtonComponent', () => {
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
 			declarations: [RadioButtonComponent],
+			imports: [ReactiveFormsModule],
 		}).compileComponents();
 	});
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ReactiveFormsModule } from '@angular/forms';
 import { TextAreaComponent } from './text-area.component';
 
 describe('TextAreaComponent', () => {
@@ -9,6 +9,7 @@ describe('TextAreaComponent', () => {
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
 			declarations: [TextAreaComponent],
+			imports: [ReactiveFormsModule],
 		}).compileComponents();
 	});
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.html
@@ -9,8 +9,10 @@
 		<input
 			#fudisTextInput
 			[formControl]="control"
-			[minlength]="minLength"
-			[maxlength]="maxLength"
+			[attr.minlength]="minLength"
+			[attr.maxlength]="maxLength"
+			[min]="minNumber"
+			[max]="maxNumber"
 			id="{{ id }}"
 			(blur)="checkErrors()"
 			[type]="type"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.scss
@@ -48,28 +48,6 @@
 			display: flex;
 			align-items: flex-end;
 			overflow: hidden;
-
-			&__unset {
-				height: initial;
-			}
-
-			&__single {
-				@include breakpoints.fudis-breakpoint('m') {
-					height: calc(typographyTokens.$fudis-text-input-line-height)
-				}
-			}
-
-			&__double {
-				@include breakpoints.fudis-breakpoint('m') {
-					height: calc(2 * typographyTokens.$fudis-text-input-line-height);
-				}
-			}
-
-			&__triple {
-				@include breakpoints.fudis-breakpoint('m') {
-					height: calc(3 * typographyTokens.$fudis-text-input-line-height);
-				}
-			}
 		}
 	}
 
@@ -89,7 +67,7 @@
 
 		&--invalid {
 			border-color: colors.$fudis-red;
-			 }	
+		}	
 	}
 
 	&__guidance {
@@ -99,16 +77,11 @@
 	
 			margin-top: spacing.$fudis-spacing-xs;
 		}
-		
-		&__character-limit-indicator {
-			@include colorMixins.fudis-text-color('gray-dark');
-		}
-	
-		&__error {
-			@include typography.fudis-body-s-regular;
-			@include colorMixins.fudis-text-color('red');
-	
-			margin-top: spacing.$fudis-spacing-xs;
-		}
 	}
+
+	// Keep number input arrows visible all the time
+  /* stylelint-disable-next-line selector-no-qualifying-type */
+  input[type=number]::-webkit-inner-spin-button {  
+		opacity: 1;
+ 	}
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.scss
@@ -28,7 +28,7 @@
 			@include colorMixins.fudis-text-color('gray-dark');
 
 			position: relative;
-			padding-bottom: spacing.$fudis-spacing-xs;
+			padding-bottom: spacing.$fudis-spacing-s;
 			overflow: hidden;
 		}
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.spec.ts
@@ -1,6 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { UntypedFormControl } from '@angular/forms';
+import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { MockComponent } from 'ng-mocks';
+import { By } from '@angular/platform-browser';
+import { ChangeDetectionStrategy } from '@angular/core';
 import { TextInputComponent } from './text-input.component';
+import { ErrorMessageComponent } from '../error-message/error-message.component';
 
 const textInputControl: UntypedFormControl = new UntypedFormControl('');
 
@@ -10,8 +15,13 @@ describe('TextInputComponent', () => {
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
-			declarations: [TextInputComponent],
-		}).compileComponents();
+			declarations: [TextInputComponent, MockComponent(ErrorMessageComponent)],
+			imports: [ReactiveFormsModule],
+		})
+			.overrideComponent(TextInputComponent, {
+				set: { changeDetection: ChangeDetectionStrategy.Default },
+			})
+			.compileComponents();
 	});
 
 	beforeEach(() => {
@@ -23,7 +33,22 @@ describe('TextInputComponent', () => {
 		fixture.detectChanges();
 	});
 
-	it('should create', () => {
-		expect(component).toBeTruthy();
+	describe('number input', () => {
+		it('should accept numbers', () => {
+			const numberInput = fixture.debugElement.query(By.css('input'));
+			component.type = 'number';
+			numberInput.nativeElement.value = '99';
+			fixture.detectChanges();
+			expect(numberInput.nativeElement.value).toContain('99');
+		});
+	});
+
+	describe('text input', () => {
+		it('should have focus when input is focused', () => {
+			const numberInput = fixture.nativeElement.querySelector('input');
+			numberInput.dispatchEvent(new Event('focus'));
+			fixture.detectChanges();
+			expect(numberInput.focus).toBeTruthy();
+		});
 	});
 });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.ts
@@ -15,41 +15,66 @@ type Error = {
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TextInputComponent {
-	// Bind input field
 	@ViewChild('fudisTextInput') input: ElementRef<HTMLInputElement>;
-
-	@Output() errorOutput: EventEmitter<Error> = new EventEmitter<Error>();
-
-	@Input() errorMsg: IFudisErrorMessages;
-
-	/**
-	 *	Label is mandatory for every input
-	 */
-	@Input() label: string;
-
-	@Input() id: string;
-
-	@Input() size?: 's' | 'm' | 'l' = 'l';
-
-	/**
-	 *	Helper or info text for the input, aligned underneath the input
-	 */
-	@Input() helpText?: string;
-
-	@Input() requiredText: string;
-
-	@Input() characterLimitIndicatorValue?: number;
 
 	@Input() control: UntypedFormControl;
 
 	/**
-	 *	Type of the input
+	 * Error message shown below the input
+	 */
+	@Input() errorMsg: IFudisErrorMessages;
+
+	/**
+	 * Input label
+	 */
+	@Input() label: string;
+
+	/**
+	 * Input id
+	 */
+	@Input() id: string;
+
+	/**
+	 * Available sizes for the input - defaults to large. Recommended size for number input is small.
+	 */
+	@Input() size?: 's' | 'm' | 'l' = 'l';
+
+	/**
+	 * Helper/info text shown below the input
+	 */
+	@Input() helpText?: string;
+
+	/**
+	 * Text to indicate that input is required, shown above the input with asterisk
+	 */
+	@Input() requiredText: string;
+
+	/**
+	 * Type of the input - defaults to 'text'
 	 */
 	@Input() type: 'email' | 'number' | 'password' | 'tel' | 'text' | 'url' = 'text';
 
+	/**
+	 * Minimium number of characters allowed by minLength
+	 */
 	@Input() minLength: number;
 
+	/**
+	 * Maximum number of characters allowed by maxLength
+	 */
 	@Input() maxLength: number;
+
+	/**
+	 * Minimum number allowed by number input's minNumber
+	 */
+	@Input() minNumber: number;
+
+	/**
+	 * Maximum number allowed by number input's maxNumber
+	 */
+	@Input() maxNumber: number;
+
+	@Output() errorOutput: EventEmitter<Error> = new EventEmitter<Error>();
 
 	showError: boolean = false;
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.stories.ts
@@ -35,6 +35,16 @@ import { IFudisErrorMessages } from '../../../types/forms';
 				[errorMsg]="validatorMessages"
 				type="email"
 				helpText="This is an example email input with multiple validations."></fudis-text-input>
+			<fudis-text-input
+				[control]="thirdTextInputControl"
+				id="unique-text-input-id-3"
+				label="Number input"
+				requiredText="Required"
+				[min]="minNumber"
+				[max]="maxNumber"
+				type="number"
+				size="s"
+				[errorMsg]="validatorMessages"></fudis-text-input>
 		</form>
 	`,
 })
@@ -43,12 +53,19 @@ class TextInputWithFormControlExampleComponent {
 
 	maxLength = 20;
 
+	minNumber = 1;
+
+	maxNumber = 99;
+
 	validatorsForSecondTextInput = [
 		Validators.minLength(this.minLength),
 		Validators.maxLength(this.maxLength),
 		Validators.required,
 		Validators.email,
 	];
+
+	validatorsForThirdTextInput = [Validators.min(this.minNumber), Validators.max(this.maxNumber), Validators.required];
+
 	/**
 	 * Options for testing purposes
 	 */
@@ -58,11 +75,15 @@ class TextInputWithFormControlExampleComponent {
 		email: 'Your input is not in email format.',
 		minlength: `Too short email. Minimum length is ${this.minLength} and maximum length is ${this.maxLength}.`,
 		maxlength: `Too long email. Minimum length is ${this.minLength} and maximum length is ${this.maxLength}.`,
+		min: `Given number is not inside the allowed range ${this.minNumber} - ${this.maxNumber}.`,
+		max: `Given number is not inside the allowed range ${this.minNumber} - ${this.maxNumber}.`,
 	};
 
 	firstTextInputControl: UntypedFormControl = new UntypedFormControl('', [Validators.required]);
 
 	secondTextInputControl: UntypedFormControl = new UntypedFormControl('', this.validatorsForSecondTextInput);
+
+	thirdTextInputControl: UntypedFormControl = new UntypedFormControl('', this.validatorsForThirdTextInput);
 
 	mainFormGroup: UntypedFormGroup = this.formBuilder.group({
 		firstTextInputControl: this.firstTextInputControl,

--- a/ngx-fudis/projects/ngx-fudis/src/test.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/test.ts
@@ -17,7 +17,10 @@ declare const require: {
 };
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+	errorOnUnknownElements: true,
+	errorOnUnknownProperties: true,
+});
 
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);


### PR DESCRIPTION
https://jira.funidata.fi/browse/DS-79

Lisätty sääntö, että testeissä ei saa enää tulla seuraavanlaisia virheitä (buildi ei mene läpi jos näitä virheitä löytyy):

```
	- NG0303: Can't bind to ‘xxx’ since it isn't a known property of ‘xxx’
	- NG0304: ‘xxx’ is not a known element
```