### PR TITLE
Ds 73 fudis notification

### DIFF
--- a/ngx-fudis/projects/documentation/development/CreatingAComponent.stories.mdx
+++ b/ngx-fudis/projects/documentation/development/CreatingAComponent.stories.mdx
@@ -11,14 +11,14 @@ import { ArgsTable, Meta, Story, Canvas, Source } from '@storybook/addon-docs';
 Generate new component to 'components' folder by running following command in `fudis/ngx-fudis` folder:
 
 ```
-ng generate -–project=ngx-fudis component components/new-component-name
+ng generate --project=ngx-fudis component components/new-component-name
 
 ```
 
 Or to a spesific directory:
 
 ```
-ng generate -–project=ngx-fudis component components/form/new-form-component
+ng generate --project=ngx-fudis component components/form/new-form-component
 ```
 
 ## Component Folder Structure

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.scss
@@ -16,7 +16,11 @@
 	justify-content: center;
 	cursor: pointer;
 	padding: 0 spacing.$fudis-spacing-xs;
-	min-width: spacing.$fudis-spacing-xxl;		
+	min-width: spacing.$fudis-spacing-xxl;
+
+	& fudis-icon {
+		display: inline-block;
+	}
 
 	&:focus {
 		@include focus.fudis-focus-generic;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.scss
@@ -18,10 +18,6 @@
 	padding: 0 spacing.$fudis-spacing-xs;
 	min-width: spacing.$fudis-spacing-xxl;
 
-	& fudis-icon {
-		display: inline-block;
-	}
-
 	&:focus {
 		@include focus.fudis-focus-generic;
 	}
@@ -35,6 +31,10 @@
 		&:focus {
 			@include focus.fudis-focus-generic;
 		}
+	}
+
+	fudis-icon {
+		display: inline-block;
 	}
 
 	&__primary {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/button/readme.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/button/readme.mdx
@@ -32,7 +32,7 @@ Button component has a input for icon component. Frequently used icons: <code>se
 
 ### Related components
 
-[IconComponent](/docs/components-icon--icon)
+[Icon](/docs/components-icon--icon)
 
 <a href="https://material.angular.io/components/button/overview" target="_blank">
 	Angular Material Button

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/icon/icon.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/icon/icon.component.html
@@ -1,5 +1,5 @@
 <svg
-	class="fudis-icon-color__{{ color }} fudis-icon-rotate__{{ rotate }} {{
+	class="fudis-icon fudis-icon-color__{{ color }} fudis-icon-rotate__{{ rotate }} {{
 		icon.includes('-small') ? 'fudis-icon__sm' : 'fudis-icon__lg'
 	}}"
 	aria-hidden="true">

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/icon/icon.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/icon/icon.component.scss
@@ -2,6 +2,10 @@
 @use '../../foundations/colors/tokens.scss' as colors;
 
 .fudis-icon {
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	
 	&-rotate {
 		&__flip-180 {
 			transform: rotate(180deg);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/icon/icon.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/icon/icon.component.scss
@@ -3,7 +3,7 @@
 
 .fudis-icon {
 	box-sizing: border-box;
-	display: flex;
+	display: inline-flex;
 	align-items: center;
 	
 	&-rotate {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/icon/icon.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/icon/icon.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, HostBinding, Input, ViewEncapsulation } from '@angular/core';
 
 import { FudisIcon, FudisIconColor } from '../../types/icons';
 
@@ -16,8 +16,11 @@ import { FudisIcon, FudisIconColor } from '../../types/icons';
 	selector: 'fudis-icon',
 	templateUrl: './icon.component.html',
 	styleUrls: ['./icon.component.scss'],
+	encapsulation: ViewEncapsulation.None,
 })
 export class IconComponent {
+	@HostBinding('class') classes = 'fudis-icon';
+
 	/**
 	 * Choose icon
 	 */

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/icon/icon.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/icon/icon.component.ts
@@ -19,6 +19,9 @@ import { FudisIcon, FudisIconColor } from '../../types/icons';
 	encapsulation: ViewEncapsulation.None,
 })
 export class IconComponent {
+	/**
+	 * Binding fudis-icon class to component wrapper
+	 */
 	@HostBinding('class') classes = 'fudis-icon';
 
 	/**

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.html
@@ -7,7 +7,7 @@
 </div>
 
 <ng-template #anchorLink>
-	<a [href]="href" class="fudis-link__anchor fudis-link__anchor__{{ size }}">
+	<a [href]="href" class="fudis-link__anchor fudis-link__anchor__{{ size }} fudis-link__anchor__{{ color }}">
 		{{ linkTitle ? linkTitle : href }}
 	</a>
 </ng-template>
@@ -18,8 +18,10 @@
 		[href]="href"
 		target="_blank"
 		rel="noopener noreferrer"
-		class="fudis-link__anchor fudis-link__anchor__{{ size }} fudis-link__anchor__external">
+		class="fudis-link__anchor fudis-link__anchor__{{ size }} fudis-link__anchor__{{
+			color
+		}} fudis-link__anchor__external">
 		{{ linkTitle ? linkTitle : href }}
-		<fudis-icon icon="external" color="primary"></fudis-icon>
+		<fudis-icon icon="external" color="{{ color }}"></fudis-icon>
 	</a>
 </ng-template>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.html
@@ -22,6 +22,6 @@
 			color
 		}} fudis-link__anchor__external">
 		{{ linkTitle ? linkTitle : href }}
-		<fudis-icon icon="external" color="{{ color }}"></fudis-icon>
+		<fudis-icon icon="external" [color]="color"></fudis-icon>
 	</a>
 </ng-template>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.scss
@@ -4,8 +4,6 @@
 
 .fudis-link {
 	&__anchor {
-		@include colors.fudis-text-color('primary');
-
 		text-decoration: underline dotted;
 
 		&:hover {
@@ -14,6 +12,14 @@
 
 		&:focus {
 			@include focus.fudis-focus-generic;
+		}
+
+		&__primary {
+			@include colors.fudis-text-color('primary');
+		}
+
+		&__default {
+			@include colors.fudis-text-color('gray-dark');
 		}
 
 		&__external {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.ts
@@ -18,7 +18,8 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
  * <fudis-link
  *     href="https://www.example.com"
  *     [isExternalLink]="true"
- *     externalLinkAriaLabel="Opens in a new window">
+ *     externalLinkAriaLabel="Opens in a new window"
+ * 	[color]="default">
  * </fudis-link>
  * ```
  */
@@ -58,7 +59,8 @@ export class LinkComponent {
 	@Input() externalLinkAriaLabel?: string;
 
 	/**
-	 * Link uses primary blue link color. "Default"" class name is a dark gray color used by icon component. Icon component inherits this color attribute when external link is used.
+	 * Link uses primary blue color.
+	 * Option to set color to 'default' which is a dark gray color. It is mainly used in links inside notification component but can be added to any link component if necessary.
 	 */
 	@Input() color: 'primary' | 'default' = 'primary';
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.ts
@@ -56,4 +56,9 @@ export class LinkComponent {
 	 * Aria-label for the external link
 	 */
 	@Input() externalLinkAriaLabel?: string;
+
+	/**
+	 * Link uses primary blue link color. "Default"" class name is a dark gray color used by icon component. Icon component inherits this color attribute when external link is used.
+	 */
+	@Input() color: 'primary' | 'default' = 'primary';
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.ts
@@ -19,7 +19,7 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
  *     href="https://www.example.com"
  *     [isExternalLink]="true"
  *     externalLinkAriaLabel="Opens in a new window"
- * 	[color]="default">
+ * 	color="default">
  * </fudis-link>
  * ```
  */

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 
 /**
  * Example usages:
@@ -28,6 +28,7 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 	templateUrl: './link.component.html',
 	styleUrls: ['./link.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,
+	encapsulation: ViewEncapsulation.None,
 })
 export class LinkComponent {
 	/**

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/nofication.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/nofication.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NotificationComponent } from './notification.component';
+
+describe('NotificationComponent', () => {
+	let component: NotificationComponent;
+	let fixture: ComponentFixture<NotificationComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [NotificationComponent],
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(NotificationComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/nofication.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/nofication.component.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { NotificationComponent } from './notification.component';
+import { MockComponent } from 'ng-mocks';
+import { IconComponent } from '../icon/icon.component';
+import { BodyTextComponent } from '../typography/body-text/body-text.component';
+import { LinkComponent } from '../link/link.component';
+import { NotificationComponent, NotificationType } from './notification.component';
 
 describe('NotificationComponent', () => {
 	let component: NotificationComponent;
@@ -8,15 +11,39 @@ describe('NotificationComponent', () => {
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
-			declarations: [NotificationComponent],
+			declarations: [
+				NotificationComponent,
+				MockComponent(IconComponent),
+				MockComponent(BodyTextComponent),
+				LinkComponent,
+			],
 		}).compileComponents();
+	});
 
+	beforeEach(() => {
 		fixture = TestBed.createComponent(NotificationComponent);
 		component = fixture.componentInstance;
 		fixture.detectChanges();
 	});
 
-	it('should create', () => {
-		expect(component).toBeTruthy();
+	function assertNotificationHasClasses(classes: string): void {
+		const childSpan = fixture.nativeElement.childNodes;
+		const componentClasses = childSpan[0].className.split(' ').sort();
+		expect(componentClasses).toEqual(classes.split(' ').sort());
+	}
+
+	function notificationVariants(variant: NotificationType): void {
+		component.variant = variant;
+		fixture.detectChanges();
+		assertNotificationHasClasses(`fudis-notification fudis-notification__${variant}`);
+	}
+
+	describe('CSS classes', () => {
+		it('should change the class according to the given notification variant', () => {
+			notificationVariants('danger');
+			notificationVariants('warning');
+			notificationVariants('success');
+			notificationVariants('light');
+		});
 	});
 });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.html
@@ -6,6 +6,7 @@
 		<ng-content></ng-content>
 		<fudis-link
 			*ngIf="link"
+			[linkTitle]="linkTitle"
 			href="{{ link }}"
 			[isExternalLink]="externalLink"
 			[externalLinkAriaLabel]="externalLinkAriaLabel"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.html
@@ -1,8 +1,6 @@
 <div class="fudis-notification fudis-notification__{{ variant }}">
 	<fudis-icon [icon]="icon"></fudis-icon>
-	<fudis-body-text
-		[size]="'l-regular'"
-		[class]="externalLink && link ? 'fudis-notification__link' : 'fudis-notification__content'">
+	<fudis-body-text [size]="'l-regular'">
 		<ng-content></ng-content>
 		<fudis-link
 			*ngIf="link"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.html
@@ -1,0 +1,6 @@
+<div class="fudis-notification fudis-notification__{{ variant }}">
+	<fudis-icon [icon]="icon"></fudis-icon>
+	<fudis-body-text [size]="'l-regular'" class="fudis-notification__content">
+		<ng-content></ng-content>
+	</fudis-body-text>
+</div>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.html
@@ -1,6 +1,14 @@
 <div class="fudis-notification fudis-notification__{{ variant }}">
 	<fudis-icon [icon]="icon"></fudis-icon>
-	<fudis-body-text [size]="'l-regular'" class="fudis-notification__content">
+	<fudis-body-text
+		[size]="'l-regular'"
+		[class]="externalLink && link ? 'fudis-notification__link' : 'fudis-notification__content'">
 		<ng-content></ng-content>
+		<fudis-link
+			*ngIf="link"
+			href="{{ link }}"
+			[isExternalLink]="externalLink"
+			[externalLinkAriaLabel]="externalLinkAriaLabel"
+			color="default"></fudis-link>
 	</fudis-body-text>
 </div>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.scss
@@ -1,0 +1,52 @@
+@use 'sass:map';
+@use '../../foundations/colors/mixins.scss' as colors;
+@use '../../foundations/focus/mixins.scss' as focus;
+@use '../../foundations/borders/mixins.scss' as borders;
+@use '../../foundations/typography/mixins.scss' as typography;
+@use '../../foundations/spacing/tokens.scss' as spacing;
+
+.fudis-notification {
+	@include borders.fudis-border-radius('2px');
+
+	display: flex;
+	width: 100%;
+	margin: 0 spacing.$fudis-spacing-xxs;
+	min-height: spacing.$fudis-spacing-m;
+	line-height: spacing.$fudis-spacing-s;
+
+	padding: 0 spacing.$fudis-spacing-s 0 spacing.$fudis-spacing-xxs;
+
+	&__content {
+		width: 100%;
+		padding-top: spacing.$fudis-spacing-xs;
+		padding-bottom: spacing.$fudis-spacing-xxs;
+	}
+
+	&__warning {
+		@include colors.fudis-bg-color('yellow-light');
+		@include borders.fudis-border('2px', 'solid', 'yellow');
+
+		border-left-width: spacing.$fudis-spacing-xs;
+	}
+
+	&__danger {
+		@include colors.fudis-bg-color('red-light');
+		@include borders.fudis-border('2px', 'solid', 'red');
+
+		border-left-width: spacing.$fudis-spacing-xs;
+	}
+
+	&__success {
+		@include colors.fudis-bg-color('green-light');
+		@include borders.fudis-border('2px', 'solid', 'green');
+
+		border-left-width: spacing.$fudis-spacing-xs;
+	}
+
+	&__light {
+		@include colors.fudis-bg-color('primary-light');
+		@include borders.fudis-border('2px', 'solid', 'primary-dark');
+
+		border-left-width: spacing.$fudis-spacing-xs;
+	}
+}

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.scss
@@ -9,17 +9,22 @@
 	@include borders.fudis-border-radius('2px');
 
 	display: flex;
+	align-items: flex-start;
 	margin: 0 spacing.$fudis-spacing-xxs;
 	padding: 0 spacing.$fudis-spacing-s 0 spacing.$fudis-spacing-xxs;
 	width: 100%;
 	min-height: spacing.$fudis-spacing-m;
-	/* stylelint-disable-next-line property-disallowed-list */
-	line-height: spacing.$fudis-spacing-s;
 
 	&__content {
 		padding-top: spacing.$fudis-spacing-xs;
-		padding-bottom: spacing.$fudis-spacing-xxs;
-		width: 100%;
+	}
+
+	&__link {
+		padding-top: 0;
+
+		fudis-link {
+			margin-left: spacing.$fudis-spacing-xxs;
+		}
 	}
 
 	&__warning {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.scss
@@ -9,17 +9,17 @@
 	@include borders.fudis-border-radius('2px');
 
 	display: flex;
-	width: 100%;
 	margin: 0 spacing.$fudis-spacing-xxs;
+	padding: 0 spacing.$fudis-spacing-s 0 spacing.$fudis-spacing-xxs;
+	width: 100%;
 	min-height: spacing.$fudis-spacing-m;
+	/* stylelint-disable-next-line property-disallowed-list */
 	line-height: spacing.$fudis-spacing-s;
 
-	padding: 0 spacing.$fudis-spacing-s 0 spacing.$fudis-spacing-xxs;
-
 	&__content {
-		width: 100%;
 		padding-top: spacing.$fudis-spacing-xs;
 		padding-bottom: spacing.$fudis-spacing-xxs;
+		width: 100%;
 	}
 
 	&__warning {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.scss
@@ -9,22 +9,14 @@
 	@include borders.fudis-border-radius('2px');
 
 	display: flex;
-	align-items: flex-start;
+	align-items: center;
 	margin: 0 spacing.$fudis-spacing-xxs;
 	padding: 0 spacing.$fudis-spacing-s 0 spacing.$fudis-spacing-xxs;
 	width: 100%;
 	min-height: spacing.$fudis-spacing-m;
 
-	&__content {
-		padding-top: spacing.$fudis-spacing-xs;
-	}
-
-	&__link {
-		padding-top: 0;
-
-		fudis-link {
-			margin-left: spacing.$fudis-spacing-xxs;
-		}
+	fudis-link {
+		margin-left: spacing.$fudis-spacing-xxs;
 	}
 
 	&__warning {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.stories.ts
@@ -1,0 +1,48 @@
+import { Story, Meta } from '@storybook/angular/types-6-0';
+import { NotificationComponent } from './notification.component';
+import readme from './readme.mdx';
+
+export default {
+	title: 'Components/NoticationComponent',
+	component: NotificationComponent,
+	parameters: {
+		docs: {
+			page: readme,
+		},
+	},
+	argTypes: {
+		icon: {
+			control: { type: 'text' },
+		},
+	},
+} as Meta;
+
+const Template: Story = (args) => ({
+	props: args,
+	template: `<fudis-notification [variant]="variant">{{content}}</fudis-notification>`,
+});
+
+export const Notification = Template.bind({});
+Notification.args = {
+	variant: 'warning',
+	content: 'Jeejee',
+};
+
+export const LinkNotification: Story = () => ({
+	template: `
+	<fudis-grid align="left" width="m">
+		<fudis-notification variant="warning"><fudis-link [href]="'https://www.example.com'"></fudis-link>! Please don't do this, okey?</fudis-notification>
+	</fudis-grid>
+	`,
+});
+
+export const AllVariants: Story = () => ({
+	template: `
+	<fudis-grid align="left" width="m">
+		<fudis-notification variant="warning">Note! Please don't do this, okey? </fudis-notification>
+		<fudis-notification variant="danger">Whoops! Some error happened. </fudis-notification>
+		<fudis-notification variant="success">You succeeded!</fudis-notification>
+		<fudis-notification variant="light">This is a totally neutral message</fudis-notification>
+	</fudis-grid>
+	`,
+});

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.stories.ts
@@ -19,7 +19,7 @@ export default {
 
 const Template: Story = (args) => ({
 	props: args,
-	template: `<fudis-notification [variant]="variant">{{content}}</fudis-notification>`,
+	template: `<fudis-notification [variant]="variant" [link]="link" [externalLink]="externalLink" [externalLinkAriaLabel]="externalLinkAriaLabel">{{content}}</fudis-notification>`,
 });
 
 export const Notification = Template.bind({});
@@ -28,13 +28,14 @@ Notification.args = {
 	content: 'Jeejee',
 };
 
-export const LinkNotification: Story = () => ({
-	template: `
-	<fudis-grid align="left" width="m">
-		<fudis-notification variant="warning"><fudis-link [href]="'https://www.example.com'"></fudis-link>! Please don't do this, okey?</fudis-notification>
-	</fudis-grid>
-	`,
-});
+export const LinkNotification = Template.bind({});
+LinkNotification.args = {
+	variant: 'warning',
+	content: 'This link leads to another site.',
+	link: 'https://www.example.com',
+	externalLink: true,
+	externalLinkAriaLabel: 'Link to another page',
+};
 
 export const AllVariants: Story = () => ({
 	template: `

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.stories.ts
@@ -3,7 +3,7 @@ import { NotificationComponent } from './notification.component';
 import readme from './readme.mdx';
 
 export default {
-	title: 'Components/Notication',
+	title: 'Components/Notification',
 	component: NotificationComponent,
 	parameters: {
 		docs: {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.stories.ts
@@ -3,7 +3,7 @@ import { NotificationComponent } from './notification.component';
 import readme from './readme.mdx';
 
 export default {
-	title: 'Components/NoticationComponent',
+	title: 'Components/Notication',
 	component: NotificationComponent,
 	parameters: {
 		docs: {
@@ -25,7 +25,7 @@ const Template: Story = (args) => ({
 export const Notification = Template.bind({});
 Notification.args = {
 	variant: 'warning',
-	content: 'Jeejee',
+	content: 'This is notification',
 };
 
 export const LinkNotification = Template.bind({});
@@ -41,8 +41,8 @@ LinkNotification.args = {
 export const AllVariants: Story = () => ({
 	template: `
 	<fudis-grid align="left" width="m">
-		<fudis-notification variant="warning">Note! Please don't do this, okey? </fudis-notification>
-		<fudis-notification variant="danger">Whoops! Some error happened. </fudis-notification>
+		<fudis-notification variant="warning">Note! Please don't do this, okey?</fudis-notification>
+		<fudis-notification variant="danger">Whoops! Some error happened.</fudis-notification>
 		<fudis-notification variant="success">You succeeded!</fudis-notification>
 		<fudis-notification variant="light">This is a totally neutral message</fudis-notification>
 	</fudis-grid>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.stories.ts
@@ -19,7 +19,7 @@ export default {
 
 const Template: Story = (args) => ({
 	props: args,
-	template: `<fudis-notification [variant]="variant" [link]="link" [externalLink]="externalLink" [externalLinkAriaLabel]="externalLinkAriaLabel">{{content}}</fudis-notification>`,
+	template: `<fudis-notification [variant]="variant" [link]="link" [linkTitle]="linkTitle" [externalLink]="externalLink" [externalLinkAriaLabel]="externalLinkAriaLabel">{{content}}</fudis-notification>`,
 });
 
 export const Notification = Template.bind({});
@@ -32,6 +32,7 @@ export const LinkNotification = Template.bind({});
 LinkNotification.args = {
 	variant: 'warning',
 	content: 'This link leads to another site.',
+	linkTitle: 'example',
 	link: 'https://www.example.com',
 	externalLink: true,
 	externalLinkAriaLabel: 'Link to another page',

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.ts
@@ -15,6 +15,22 @@ export class NotificationComponent implements OnChanges, OnInit {
 	@Input() variant?: NotificationType;
 
 	/**
+	 * Add link href address
+	 */
+	@Input() link: string;
+
+	/**
+	 * Option to create an external link to point a target page on another domain.
+	 * External link contains external icon and assistive aria-label
+	 */
+	@Input() externalLink: boolean = false;
+
+	/**
+	 * Aria-label for the external link
+	 */
+	@Input() externalLinkAriaLabel?: string;
+
+	/**
 	 * Icon for notification
 	 */
 	icon: FudisIcon;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.ts
@@ -1,0 +1,50 @@
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { FudisIcon } from '../../types/icons';
+
+export type NotificationType = 'warning' | 'danger' | 'success' | 'light';
+
+@Component({
+	selector: 'fudis-notification',
+	templateUrl: './notification.component.html',
+	styleUrls: ['./notification.component.scss'],
+})
+export class NotificationComponent implements OnChanges, OnInit {
+	/**
+	 * Notification variant options
+	 */
+	@Input() variant?: NotificationType;
+
+	/**
+	 * Icon for notification
+	 */
+	icon: FudisIcon;
+
+	ngOnInit(): void {
+		this.getClasses();
+	}
+
+	ngOnChanges(changes: SimpleChanges): void {
+		if (!changes['icon']) {
+			this.getClasses();
+		}
+	}
+
+	private getClasses(): void {
+		switch (this.variant) {
+			case 'warning':
+				this.icon = 'exclamation-mark-circle';
+				break;
+			case 'danger':
+				this.icon = 'alert';
+				break;
+			case 'success':
+				this.icon = 'checkmark-circle';
+				break;
+			case 'light':
+				this.icon = 'info-circle';
+				break;
+			default:
+				break;
+		}
+	}
+}

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.ts
@@ -31,20 +31,34 @@ export class NotificationComponent implements OnChanges, OnInit {
 	@Input() externalLinkAriaLabel?: string;
 
 	/**
+	 * Title for the link, if not defined title will be the same as link URL
+	 */
+	@Input() linkTitle?: string;
+
+	/**
 	 * Icon for notification
 	 */
 	icon: FudisIcon;
 
+	/**
+	 * Initialization
+	 */
 	ngOnInit(): void {
 		this.getClasses();
 	}
 
+	/**
+	 * Detecting icon changes
+	 */
 	ngOnChanges(changes: SimpleChanges): void {
 		if (!changes['icon']) {
 			this.getClasses();
 		}
 	}
 
+	/**
+	 * Used to initialize notifications variant icons
+	 */
 	private getClasses(): void {
 		switch (this.variant) {
 			case 'warning':

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/readme.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/readme.mdx
@@ -14,10 +14,19 @@ Notifications are often informative contextual notifications that cannot be clic
 	<Story id="components-noticationcomponent--all-variants"></Story>
 </Canvas>
 
+### Link notification
+
+Notification component property `link` accepts href address as a string. When link referes to external site `externalLink` property should be set on true. This will add an external link icon to a link. It is recommended to use `externalLinkAriaLabel` in order describe link action to screen reader users. 
+
+<Canvas>
+	<Story id="components-noticationcomponent--link-notification"></Story>
+</Canvas>
+
 ### Accessibility
 
 - Notification background- and text color contrast ratio meets AA and AAA levels.
 - Notification content is accessible by screen readers.
+- Notifications with a link to external source have descriptive aria-label
 
 ### Related components
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/readme.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/readme.mdx
@@ -1,0 +1,30 @@
+import { ArgsTable, Meta, Story, Canvas } from '@storybook/addon-docs';
+import { linkTo } from '@storybook/addon-links';
+import { NotificationComponent } from './notification.component';
+
+<Meta title="Notification" component={NotificationComponent} />
+
+# Notification
+
+Notifications are often informative contextual notifications that cannot be clicked away. The colors currently used are yellow `variant: "warning"`, red `variant: "danger"`, green `variant: "success"` and blue `variant: "light"`. The most common color is yellow, which is used in notes. Blue and green contextual notifications are rare. Red notification describes an error situation and green the possibility/success of some function. Blue, on the other hand, is a neutral guideline.
+
+## Examples
+
+<Canvas>
+	<Story id="components-noticationcomponent--all-variants"></Story>
+</Canvas>
+
+### Accessibility
+
+- Notification background- and text color contrast ratio meets AA and AAA levels.
+- Notification content is accessible by screen readers.
+
+### Related components
+
+[IconComponent](/docs/components-icon--icon)
+
+[Link](/docs/components-link--link)
+
+## Properties
+
+<ArgsTable of={NotificationComponent} />

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/readme.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/readme.mdx
@@ -6,12 +6,12 @@ import { NotificationComponent } from './notification.component';
 
 # Notification
 
-Notifications are often informative contextual notifications that cannot be clicked away. The colors currently used are yellow `variant: "warning"`, red `variant: "danger"`, green `variant: "success"` and blue `variant: "light"`. The most common color is yellow, which is used in notes. Blue and green contextual notifications are rare. Red notification describes an error situation and green the possibility/success of some function. Blue, on the other hand, is a neutral guideline.
+Yellow notification is used in notes. Red notification describes an error situation. Green indicates the possibility or success of some function. Blue, on the other hand, is a neutral guideline.
 
 ## Examples
 
 <Canvas>
-	<Story id="components-noticationcomponent--all-variants"></Story>
+	<Story id="components-notication--all-variants"></Story>
 </Canvas>
 
 ### Link notification
@@ -19,7 +19,7 @@ Notifications are often informative contextual notifications that cannot be clic
 Notification component property `link` accepts href address as a string. This link address is shown as default link title, but it can be changed with optinal `titleLink` property. When link referes to external site `externalLink` property should be set on true. This will add an external link icon to a link. It is recommended to use `externalLinkAriaLabel` in order describe link action to screen reader users.
 
 <Canvas>
-	<Story id="components-noticationcomponent--link-notification"></Story>
+	<Story id="components-notication--link-notification"></Story>
 </Canvas>
 
 ### Accessibility
@@ -30,7 +30,7 @@ Notification component property `link` accepts href address as a string. This li
 
 ### Related components
 
-[IconComponent](/docs/components-icon--icon)
+[Icon](/docs/components-icon--icon)
 
 [Link](/docs/components-link--link)
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/readme.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/readme.mdx
@@ -6,7 +6,7 @@ import { NotificationComponent } from './notification.component';
 
 # Notification
 
-Yellow notification is used in notes. Red notification describes an error situation. Green indicates the possibility or success of some function. Blue, on the other hand, is a neutral guideline.
+Notifications are often informative contextual notifications that cannot be clicked away. The colors currently used are yellow `variant: “warning”`, red `variant: “danger”`, green `variant: “success”` and blue `variant: “light”`. Yellow notification is used in notes. Red notification describes an error situation. Green indicates the possibility or success of some function. Blue, on the other hand, is a neutral guideline.
 
 ## Examples
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/readme.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/readme.mdx
@@ -16,7 +16,7 @@ Notifications are often informative contextual notifications that cannot be clic
 
 ### Link notification
 
-Notification component property `link` accepts href address as a string. When link referes to external site `externalLink` property should be set on true. This will add an external link icon to a link. It is recommended to use `externalLinkAriaLabel` in order describe link action to screen reader users. 
+Notification component property `link` accepts href address as a string. This link address is shown as default link title, but it can be changed with optinal `titleLink` property. When link referes to external site `externalLink` property should be set on true. This will add an external link icon to a link. It is recommended to use `externalLinkAriaLabel` in order describe link action to screen reader users.
 
 <Canvas>
 	<Story id="components-noticationcomponent--link-notification"></Story>
@@ -26,7 +26,7 @@ Notification component property `link` accepts href address as a string. When li
 
 - Notification background- and text color contrast ratio meets AA and AAA levels.
 - Notification content is accessible by screen readers.
-- Notifications with a link to external source have descriptive aria-label
+- Notifications with a link to external source have descriptive aria-label.
 
 ### Related components
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.component.html
@@ -1,3 +1,6 @@
-<p class="fudis-body-text fudis-body-text__{{ size }}">
+<p
+	class="fudis-body-text__paragraph fudis-body-text__{{ size }}"
+	[class.fudis-body-text__margin-bottom__m]="marginBottom === 'm'"
+	[class.fudis-body-text__margin-bottom__l]="marginBottom === 'l'">
 	<ng-content></ng-content>
 </p>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.component.scss
@@ -27,6 +27,10 @@
 
 	&__paragraph {
 		margin: 0;
+
+		fudis-link {
+			display: inline-block;
+		}
 	}
 
 	&__margin-bottom {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.component.scss
@@ -28,13 +28,14 @@
 	&__paragraph {
 		margin: 0;
 	}
+
 	&__margin-bottom {
 		&__m {
 			margin-bottom: spacing.$fudis-spacing-m;
 		}
+
 		&__l {
 			margin-bottom: spacing.$fudis-spacing-l;
 		}
 	}
 }
-

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.component.scss
@@ -1,5 +1,6 @@
 @use '../../../foundations/typography/mixins' as typography;
 @use '../../../foundations/colors/mixins.scss' as colorMixins;
+@use '../../../foundations/spacing/tokens.scss' as spacing;
 
 .fudis-body-text {
 	@include colorMixins.fudis-text-color('gray-dark');
@@ -23,4 +24,17 @@
 	&__l-light {
 		@include typography.fudis-body-l-light;
 	}
+
+	&__paragraph {
+		margin: 0;
+	}
+	&__margin-bottom {
+		&__m {
+			margin-bottom: spacing.$fudis-spacing-m;
+		}
+		&__l {
+			margin-bottom: spacing.$fudis-spacing-l;
+		}
+	}
 }
+

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.component.ts
@@ -1,14 +1,19 @@
-import { Component, Input, HostBinding } from '@angular/core';
+import { Component, Input, HostBinding, ViewEncapsulation } from '@angular/core';
 
 type BodyTextSize = 'l-regular' | 'm-regular' | 's-regular' | 'l-light' | 'm-light';
+
+type MarginBottomSize = 'm' | 'l' | 0 | '0';
 
 @Component({
 	selector: 'fudis-body-text',
 	templateUrl: './body-text.component.html',
 	styleUrls: ['./body-text.component.scss'],
+	encapsulation: ViewEncapsulation.None,
 })
 export class BodyTextComponent {
 	@HostBinding('class') classes = 'fudis-body-text';
 
 	@Input() size: BodyTextSize = 'm-regular';
+
+	@Input() marginBottom: MarginBottomSize = 0;
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.stories.ts
@@ -4,17 +4,29 @@ import { BodyTextComponent } from './body-text.component';
 export default {
 	title: 'Components/Typography/BodyText',
 	component: BodyTextComponent,
+	argTypes: {
+		marginBottom: {
+			options: [0, 'm', 'l'],
+			control: { type: 'radio' },
+		},
+	},
 } as Meta;
 
-const Template: Story<BodyTextComponent> = () => ({
+const Template: Story = (args) => ({
+	props: args,
 	template: `
-  <fudis-body-text size="m-regular">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, 
-  quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore 
-  eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</fudis-body-text>
-`,
+	<fudis-grid width="m" align="left">
+		<div>
+			<fudis-body-text [size]="size" [marginBottom]="marginBottom">{{content}}</fudis-body-text>
+			<fudis-body-text [size]="size" [marginBottom]="marginBottom">{{content}}</fudis-body-text>
+		</div>
+	</fudis-grid>`,
 });
 
 export const BodyText = Template.bind({});
 BodyText.args = {
 	size: 'l-regular',
+	marginBottom: 'm',
+	content:
+		'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
 };

--- a/ngx-fudis/projects/ngx-fudis/src/lib/foundations/typography/mixins.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/foundations/typography/mixins.scss
@@ -8,7 +8,6 @@
 // Body Text
 
 @mixin fudis-body-l-light {
-  margin-bottom: spacing.$fudis-spacing-l;
   line-height: tokens.$fudis-body-l-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-body-l-font-size;
@@ -16,7 +15,6 @@
 }
 
 @mixin fudis-body-l-regular {
-  margin-bottom: spacing.$fudis-spacing-l;
   line-height: tokens.$fudis-body-l-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-body-l-font-size;
@@ -24,7 +22,6 @@
 }
 
 @mixin fudis-body-m-light {
-  margin-bottom: spacing.$fudis-spacing-m;
   line-height: tokens.$fudis-body-m-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-body-m-font-size;
@@ -32,7 +29,6 @@
 }
 
 @mixin fudis-body-m-regular {
-  margin-bottom: spacing.$fudis-spacing-m;
   line-height: tokens.$fudis-body-m-line-height;
   font-family: tokens.$fudis-font-family;
   font-size: tokens.$fudis-body-m-font-size;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/ngx-fudis.module.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/ngx-fudis.module.ts
@@ -36,6 +36,7 @@ import { RadioButtonGroupComponent } from './components/form/radio-button-group/
 import { TextInputComponent } from './components/form/text-input/text-input.component';
 import { TextSpacingComponent } from './components/typography/text-spacing/text-spacing.component';
 import { TextAreaComponent } from './components/form/text-area/text-area.component';
+import { NotificationComponent } from './components/notification/notification.component';
 
 @NgModule({
 	/*
@@ -68,6 +69,7 @@ import { TextAreaComponent } from './components/form/text-area/text-area.compone
 		TextInputComponent,
 		TextSpacingComponent,
 		TextAreaComponent,
+		NotificationComponent,
 	],
 	/*
 	 * Include imports outside of Fudis components in 'imports' array below.
@@ -109,6 +111,7 @@ import { TextAreaComponent } from './components/form/text-area/text-area.compone
 		IconComponent,
 		LegendComponent,
 		LinkComponent,
+		NotificationComponent,
 		RadioButtonGroupComponent,
 		TextAreaComponent,
 		TextInputComponent,

--- a/ngx-fudis/projects/ngx-fudis/src/lib/ngx-fudis.module.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/ngx-fudis.module.ts
@@ -31,12 +31,12 @@ import { IconComponent } from './components/icon/icon.component';
 import { LabelComponent } from './components/form/label/label.component';
 import { LegendComponent } from './components/form/legend/legend.component';
 import { LinkComponent } from './components/link/link.component';
+import { NotificationComponent } from './components/notification/notification.component';
 import { RadioButtonComponent } from './components/form/radio-button-group/radio-button/radio-button.component';
 import { RadioButtonGroupComponent } from './components/form/radio-button-group/radio-button-group.component';
 import { TextInputComponent } from './components/form/text-input/text-input.component';
 import { TextSpacingComponent } from './components/typography/text-spacing/text-spacing.component';
 import { TextAreaComponent } from './components/form/text-area/text-area.component';
-import { NotificationComponent } from './components/notification/notification.component';
 
 @NgModule({
 	/*
@@ -64,12 +64,12 @@ import { NotificationComponent } from './components/notification/notification.co
 		LabelComponent,
 		LegendComponent,
 		LinkComponent,
+		NotificationComponent,
 		RadioButtonComponent,
 		RadioButtonGroupComponent,
 		TextInputComponent,
 		TextSpacingComponent,
 		TextAreaComponent,
-		NotificationComponent,
 	],
 	/*
 	 * Include imports outside of Fudis components in 'imports' array below.

--- a/ngx-fudis/projects/ngx-fudis/src/public-api.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/public-api.ts
@@ -20,6 +20,7 @@ export { HeadingComponent } from './lib/components/typography/heading/heading.co
 export { IconComponent } from './lib/components/icon/icon.component';
 export { LegendComponent } from './lib/components/form/legend/legend.component';
 export { LinkComponent } from './lib/components/link/link.component';
+export { NotificationComponent } from './lib/components/notification/notification.component';
 export { RadioButtonGroupComponent } from './lib/components/form/radio-button-group/radio-button-group.component';
 export { TextAreaComponent } from './lib/components/form/text-area/text-area.component';
 export { TextInputComponent } from './lib/components/form/text-input/text-input.component';


### PR DESCRIPTION
Luotiin notifikaatio komponentti, sekä siihen liittyvät testit ja storybook dokumentaatio.Notifikaation testit testaavat vain komponentin luokkanimiä. 

Lisäksi:
Link component:
- Lisättiin color proppi, jonka avulla voidaan vaihtaa linkin väriä tarvittaessa (esim. notifikaation linkki aina tumman harmaa).
- External ikoni komponentti ottaa vastaan myös color propsin.
Body text componentti:
- poistettiin margin-bottom typografia mixineistä.
- Lisättiin margin-bottom propsi, jonka default on 0.
- Muutettiin komponentin dokumentaatiota, jotta pystyttiin paremmin demoamaan uudet margin-bottom koot 0,m, ja l. (Huom! kokoa s ei ole figma suunnitelmissa, mutta mahdollisesti tehdään myöhemmin).
- Lisättiin luokka fudis-body-text__paragraph. Tekstiin joukkoon lisättävä linkki komponentti saa display inline-block asettelun, jolloin se kulkee tekstin mukana.