### PR TITLE
Fix Storybook deployment environments' status updates

### DIFF
--- a/.github/workflows/complete_storybook_deployment.yaml
+++ b/.github/workflows/complete_storybook_deployment.yaml
@@ -1,0 +1,39 @@
+# Update Storybook deployment's environment status and metadata after GH Pages deployment completes.
+name: Complete Storybook deployment
+
+on:
+  workflow_run:
+    workflows:
+      - pages-build-deployment
+    types:
+      - completed
+
+jobs:
+  update-environment:
+    name: Update GH deployment status
+    runs-on: ubuntu-22.04
+    permissions:
+      deployments: write
+    steps:
+      - name: Parse target deployment ID and path from commit message
+        id: parse-deployment-data
+        env:
+          MSG: ${{ github.event.workflow_run.head_commit.message }}
+        run: |
+          echo "id=${MSG%%/*}" >> $GITHUB_OUTPUT
+          echo "path=${MSG##*/}" >> $GITHUB_OUTPUT
+      - name: Format deployment URL
+        id: url
+        env:
+          REPO: ${{ github.repository }}
+        run: echo "url=https://${{ github.repository_owner }}.github.io/${REPO##*/}/${{ steps.parse-deployment-data.outputs.path }}" >> $GITHUB_OUTPUT
+      - name: Complete deployment (success)
+        if: github.event.workflow_run.conclusion == 'success'
+        uses: octokit/request-action@v2.1.7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          route: POST /repos/${{ github.repository }}/deployments/{deployment_id}/statuses
+          deployment_id: ${{ steps.parse-deployment-data.outputs.id }}
+          state: success
+          environment_url: ${{ steps.url.outputs.url }}

--- a/.github/workflows/storybook_publish.yaml
+++ b/.github/workflows/storybook_publish.yaml
@@ -39,6 +39,8 @@ jobs:
   publish-storybook:
     name: Build and deploy Storybook
     runs-on: ubuntu-22.04
+    needs:
+      - create-deployment
     permissions:
       contents: write
     steps:
@@ -56,7 +58,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ngx-fudis/static
           destination_dir: ${{ inputs.path }}
-      # Optional deploy to 'latest'.
+          full_commit_message: ${{ needs.create-deployment.outputs.deployment_id }}/${{ inputs.path }}
+          # Optional deploy to 'latest'.
       - name: Deploy to Pages under "latest" (optional)
         if: inputs.latest
         uses: peaceiris/actions-gh-pages@v3
@@ -64,13 +67,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ngx-fudis/static
           destination_dir: latest
-      - name: Format deployment URL
-        id: url
-        env:
-          REPO: ${{ github.repository }}
-        run: echo "url=https://${{ github.repository_owner }}.github.io/${REPO##*/}/${{ inputs.path }}" >> $GITHUB_OUTPUT
-    outputs:
-      url: ${{ steps.url.outputs.url }}
 
   complete-deployment:
     name: Update GH deployment status
@@ -83,18 +79,18 @@ jobs:
       deployments: write
     steps:
       # TODO: Refactor repetition away.
-      - name: Complete deployment (success)
-        if: needs.publish-storybook.result == 'success'
-        uses: octokit/request-action@v2.1.7
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          route: POST /repos/${{ github.repository }}/deployments/{deployment_id}/statuses
-          deployment_id: ${{ needs.create-deployment.outputs.deployment_id }}
-          ref: ${{ inputs.path }}
-          environment: docs-${{ inputs.path }}
-          state: success
-          environment_url: ${{ needs.publish-storybook.outputs.url }}
+      # - name: Complete deployment (success)
+      #   if: needs.publish-storybook.result == 'success'
+      #   uses: octokit/request-action@v2.1.7
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     route: POST /repos/${{ github.repository }}/deployments/{deployment_id}/statuses
+      #     deployment_id: ${{ needs.create-deployment.outputs.deployment_id }}
+      #     ref: ${{ inputs.path }}
+      #     environment: docs-${{ inputs.path }}
+      #     state: success
+      #     environment_url: ${{ needs.publish-storybook.outputs.url }}
       - name: Complete deployment (failure)
         if: needs.publish-storybook.result == 'failure'
         uses: octokit/request-action@v2.1.7


### PR DESCRIPTION
- Currently the deployment environments are be updated with `success` status and URL before the deployment has actually finished. This PR moves the status updates to run after the `pages-build-deployment` workflow. Now PR's won't include broken URL's and reflect the deployment status more accurately.