### PR TITLE
DS-181: Footer, tests & documentation

### DIFF
--- a/ngx-fudis/projects/dev/src/app/app.component.html
+++ b/ngx-fudis/projects/dev/src/app/app.component.html
@@ -78,24 +78,12 @@
 
 		<fudis-footer [logoAltText]="'Link to Funidata homepage'">
 			<ng-template fudisFooterRight>
-				<fudis-link
-					[href]="'example.com'"
-					[linkTitle]="'Tietosuojaseloste'"
-					[isExternalLink]="true"
-					[externalLinkAriaLabel]="'Link to external source'" />
-				<fudis-link
-					[href]="'example.com'"
-					[linkTitle]="'Saavutettavuusseloste'"
-					[isExternalLink]="true"
-					[externalLinkAriaLabel]="'Link to external source'" />
+				<fudis-link [href]="'example.com'" [linkTitle]="'Tietosuojaseloste'" [isExternalLink]="true" />
+				<fudis-link [href]="'example.com'" [linkTitle]="'Saavutettavuusseloste'" [isExternalLink]="true" />
 				<fudis-link [href]="'example.com'" [linkTitle]="'Järjestelmätiedot'" />
 			</ng-template>
 			<ng-template fudisFooterLeft>
-				<fudis-link
-					[href]="'example.com'"
-					[linkTitle]="'Promo link'"
-					[isExternalLink]="true"
-					[externalLinkAriaLabel]="'Link to external source'" />
+				<fudis-link [href]="'example.com'" [linkTitle]="'Promo link'" [isExternalLink]="true" />
 			</ng-template>
 		</fudis-footer>
 	</div>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/footer/footer.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/footer/footer.component.html
@@ -7,14 +7,15 @@
 		[marginSides]="'responsive'"
 		[width]="'xxl'"
 		[marginTop]="'xxl'">
-		<ng-container *ngIf="contentLeft">
-			<fudis-grid-item [alignX]="{ xs: 'center', sm: 'start' }" class="fudis-footer__item">
-				<a href="https://www.funidata.fi/" class="fudis-footer__item__logo"
-					><img src="fd-logo.svg" alt="{{ logoAltText }}"
-				/></a>
+		<fudis-grid-item [alignX]="{ xs: 'center', sm: 'start' }" class="fudis-footer__item">
+			<a href="https://www.funidata.fi/" class="fudis-footer__item__logo"
+				><img src="fd-logo.svg" alt="{{ logoAltText }}"
+			/></a>
+			<ng-container *ngIf="contentLeft">
 				<ng-container *ngTemplateOutlet="contentLeft!.templateRef" />
-			</fudis-grid-item>
-		</ng-container>
+			</ng-container>
+		</fudis-grid-item>
+
 		<ng-container *ngIf="contentRight">
 			<fudis-grid-item [alignX]="{ xs: 'center', sm: 'end' }" class="fudis-footer__item">
 				<ng-container *ngTemplateOutlet="contentRight!.templateRef" />

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/footer/footer.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/footer/footer.component.scss
@@ -1,7 +1,5 @@
 @use '../../foundations/typography/mixins.scss' as typography;
-@use '../../foundations/typography/tokens.scss' as typographyTokens;
 @use '../../foundations/colors/mixins.scss' as colorMixins;
-@use '../../foundations/colors/tokens.scss' as color;
 @use '../../foundations/spacing/tokens.scss' as spacing;
 @use '../../foundations/breakpoints/mixins.scss' as breakpoints;
 @use '../../foundations/utilities/mixins.scss' as utilities;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/footer/footer.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/footer/footer.component.spec.ts
@@ -1,24 +1,99 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { Component } from '@angular/core';
+import { MockComponent } from 'ng-mocks';
+import { By } from '@angular/platform-browser';
 import { FooterComponent } from './footer.component';
 import { GridComponent } from '../grid/grid/grid.component';
 import { FudisGridService } from '../../directives/grid/grid-service/grid.service';
+import {
+	FooterContentLeftDirective,
+	FooterContentRightDirective,
+} from '../../directives/content-projection/content/content.directive';
+import { GridItemComponent } from '../grid/grid-item/grid-item.component';
+import { LinkComponent } from '../link/link.component';
+import { IconComponent } from '../icon/icon.component';
+
+@Component({
+	selector: 'fudis-mock-footer',
+	template: `<fudis-footer [logoAltText]="'Link to Funidata homepage'">
+		<ng-template fudisFooterRight>
+			<fudis-link [href]="'example.com'" [linkTitle]="'Tietosuojaseloste'" [isExternalLink]="true" />
+			<fudis-link [href]="'example.com'" [linkTitle]="'Saavutettavuusseloste'" [isExternalLink]="true" />
+			<fudis-link [href]="'example.com'" [linkTitle]="'Järjestelmätiedot'" />
+		</ng-template>
+		<ng-template fudisFooterLeft>
+			<fudis-link [href]="'example.com'" [linkTitle]="'Promo link'" [isExternalLink]="true" />
+		</ng-template>
+	</fudis-footer>`,
+})
+class MockFooterComponent {}
 
 describe('FooterComponent', () => {
-	let component: FooterComponent;
-	let fixture: ComponentFixture<FooterComponent>;
+	let component: MockFooterComponent;
+	let fixture: ComponentFixture<MockFooterComponent>;
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			declarations: [FooterComponent, GridComponent],
+			declarations: [
+				FooterComponent,
+				GridComponent,
+				GridItemComponent,
+				LinkComponent,
+				FooterContentLeftDirective,
+				FooterContentRightDirective,
+				MockFooterComponent,
+				MockComponent(IconComponent),
+			],
 			providers: [FudisGridService],
-		});
-		fixture = TestBed.createComponent(FooterComponent);
+		}).compileComponents();
+	});
+
+	beforeEach(() => {
+		fixture = TestBed.createComponent(MockFooterComponent);
 		component = fixture.componentInstance;
 		fixture.detectChanges();
 	});
 
+	function getFooterGridElem() {
+		return fixture.debugElement.query(By.directive(GridComponent));
+	}
+
 	it('should create', () => {
 		expect(component).toBeTruthy();
+	});
+
+	describe('CSS classes', () => {
+		it('should have fudis-footer class', () => {
+			const elem = fixture.debugElement.query(By.css('.fudis-footer'));
+			expect(elem.nativeElement.className).toEqual('fudis-footer');
+		});
+	});
+
+	describe('Contents', () => {
+		it('should have fudis-grid element present', () => {
+			expect(getFooterGridElem()).toBeTruthy();
+		});
+
+		it('should have fudis-grid-item elements present', () => {
+			expect(getFooterGridElem().nativeElement.children.length).toEqual(2);
+		});
+
+		describe('Footer right side', () => {
+			it('should have three child elements', () => {
+				expect(getFooterGridElem().nativeElement.children[1].children.length).toEqual(3);
+			});
+		});
+
+		describe('Footer left side', () => {
+			it('should have two child elements', () => {
+				expect(getFooterGridElem().nativeElement.children[0].children.length).toEqual(2);
+			});
+
+			it('should have Funidata logo visible', () => {
+				const firstGridItemElem = getFooterGridElem().nativeElement.children[0];
+				const anchorElem = firstGridItemElem.querySelector('.fudis-footer__item__logo');
+				expect(anchorElem.children.length).toEqual(1);
+			});
+		});
 	});
 });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/footer/footer.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/footer/footer.stories.ts
@@ -18,26 +18,14 @@ export default {
 const Template: StoryFn<FooterComponent> = (args: FooterComponent) => ({
 	props: args,
 	template: html`
-		<fudis-footer [logoAltText]="'logoAltText'">
+		<fudis-footer [logoAltText]="logoAltText">
 			<ng-template fudisFooterRight>
-				<fudis-link
-					[href]="'example.com'"
-					[linkTitle]="'Tietosuojaseloste'"
-					[isExternalLink]="true"
-					[externalLinkAriaLabel]="'Link to external source'" />
-				<fudis-link
-					[href]="'example.com'"
-					[linkTitle]="'Saavutettavuusseloste'"
-					[isExternalLink]="true"
-					[externalLinkAriaLabel]="'Link to external source'" />
+				<fudis-link [href]="'example.com'" [linkTitle]="'Tietosuojaseloste'" [isExternalLink]="true" />
+				<fudis-link [href]="'example.com'" [linkTitle]="'Saavutettavuusseloste'" [isExternalLink]="true" />
 				<fudis-link [href]="'example.com'" [linkTitle]="'Järjestelmätiedot'" />
 			</ng-template>
 			<ng-template fudisFooterLeft>
-				<fudis-link
-					[href]="'example.com'"
-					[linkTitle]="'Promo link'"
-					[isExternalLink]="true"
-					[externalLinkAriaLabe]="'Link to external source'" />
+				<fudis-link [href]="'example.com'" [linkTitle]="'Promo link'" [isExternalLink]="true" />
 			</ng-template>
 		</fudis-footer>
 	`,

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/footer/readme.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/footer/readme.mdx
@@ -9,9 +9,9 @@ import { Source } from '@storybook/blocks';
 # Footer
 
 Fudis Footer is static component to be used as application's footer in the bottom of the page. It is designed to use [Fudis Link](/docs/components-link--link) components as its content. Through content projection it's easier for developers to change related links depending on the application.
-By using directives `fudisFooterRight` or `fudisFooterLeft`, developers can determine which side of the footer links are displayed.
+By using directives `fudisFooterRight` and/or `fudisFooterLeft`, developers can determine which side of the footer links are displayed.
 The only fixed element in Fudis Footer is Funidata logo with a link to Funidata's homepage.
-This logo holds an mandatory image alt-text that can be changed with `logoAltText` when the application language changes.
+This logo holds a mandatory image alt-text that can be changed with `logoAltText` when the application language changes.
 
 <Canvas of={FooterComponentStories.Footer} />
 
@@ -24,8 +24,9 @@ This logo holds an mandatory image alt-text that can be changed with `logoAltTex
 
 ### Related components
 
-- [Link](/docs/components-link--link)
-- [Grid](/docs/components-grid-grid--example)
+[Link](/docs/components-link--link)
+
+[Grid](/docs/components-grid-grid--example)
 
 ## Properties
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.html
@@ -24,7 +24,7 @@
 
 <ng-template #externalLink>
 	<a
-		attr.aria-label="{{ linkTitle ? linkTitle : href }}, {{ externalLinkAriaLabel }}"
+		attr.aria-label="{{ linkTitle ? linkTitle : href }}, {{ _externalLinkAriaLabel }}"
 		[href]="href ? href : null"
 		target="_blank"
 		rel="noopener noreferrer"
@@ -32,6 +32,6 @@
 			color
 		}} fudis-link__anchor__external">
 		{{ linkTitle ? linkTitle : href }}
-		<fudis-icon icon="external" [color]="color"></fudis-icon>
+		<fudis-icon [icon]="'external'" [color]="color"></fudis-icon>
 	</a>
 </ng-template>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.spec.ts
@@ -53,12 +53,11 @@ describe('LinkComponent', () => {
 		it('should have assistive aria-label for screen readers', () => {
 			component.href = 'www.example.com';
 			component.isExternalLink = true;
-			component.externalLinkAriaLabel = 'Open into a new tab';
 			fixture.detectChanges();
 			const externalLinkComponent = fixture.debugElement.query(By.css('.fudis-link__anchor__external'));
-			expect(externalLinkComponent.nativeElement.getAttribute('aria-label'))
-				.withContext(component.externalLinkAriaLabel)
-				.toEqual('www.example.com, Open into a new tab');
+			expect(externalLinkComponent.nativeElement.getAttribute('aria-label')).toEqual(
+				'www.example.com, (opens in a new tab)'
+			);
 		});
 	});
 });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.ts
@@ -1,14 +1,16 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, Signal, effect } from '@angular/core';
+import { FudisTranslationService } from '../../utilities/translation/translation.service';
+import { FudisTranslationConfig } from '../../types/miscellaneous';
 
 /**
  * Example usages:
  *
  * Inside another element e.g. fudis-heading
  * ```
- * <fudis-heading tag="h3">
+ * <fudis-heading [tag]="'h3'">
  * 		<fudis-link
- *     		href="/path-to"
- *     		linkTitle="Heading link">
+ *     		[href]="/path-to"
+ *     		[linkTitle]="'Heading link'">
  * 		</fudis-link>
  * </fudis-heading>
  * ```
@@ -16,9 +18,8 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
  * External link with icon and assistive aria-label
  * ```
  * <fudis-link
- *     href="https://www.example.com"
+ *     [href]="https://www.example.com"
  *     [isExternalLink]="true"
- *     externalLinkAriaLabel="Opens in a new window"
  * 	color="default">
  * </fudis-link>
  * ```
@@ -31,6 +32,14 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LinkComponent {
+	constructor(private _translationService: FudisTranslationService) {
+		effect(() => {
+			this._translations = this._translationService.getTranslations();
+
+			this._externalLinkAriaLabel = this._translations().LINK.EXTERNAL_LINK;
+		});
+	}
+
 	/**
 	 * Link URL using native href
 	 */
@@ -63,13 +72,18 @@ export class LinkComponent {
 	@Input() isExternalLink: boolean = false;
 
 	/**
-	 * Aria-label for the external link
-	 */
-	@Input() externalLinkAriaLabel: string;
-
-	/**
 	 * Link uses primary blue color.
 	 * Option to set color to 'default' which is a dark gray color. It is mainly used in links inside notification component but can be added to any link component if necessary.
 	 */
 	@Input() color: 'primary' | 'default' = 'primary';
+
+	/**
+	 * Aria-label for the external link
+	 */
+	protected _externalLinkAriaLabel: string;
+
+	/**
+	 * Fudis translations
+	 */
+	protected _translations: Signal<FudisTranslationConfig>;
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.html
@@ -10,7 +10,6 @@
 				[linkTitle]="linkTitle"
 				[href]="link"
 				[isExternalLink]="externalLink"
-				[externalLinkAriaLabel]="externalLinkAriaLabel"
 				[color]="'default'"></fudis-link>
 		</fudis-body-text>
 	</ng-container>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.stories.ts
@@ -10,16 +10,21 @@ export default {
 			page: readme,
 		},
 	},
-	argTypes: {
-		icon: {
-			control: { type: 'text' },
-		},
-	},
+	argTypes: {},
 } as Meta;
+
+const html = String.raw;
 
 const Template: StoryFn = (args) => ({
 	props: args,
-	template: `<fudis-notification [variant]="variant" [ariaVariantText]="ariaVariantText" [link]="link" [linkTitle]="linkTitle" [externalLink]="externalLink" [externalLinkAriaLabel]="externalLinkAriaLabel">{{content}}</fudis-notification>`,
+	template: html`<fudis-notification
+		[variant]="variant"
+		[ariaVariantText]="ariaVariantText"
+		[link]="link"
+		[linkTitle]="linkTitle"
+		[externalLink]="externalLink"
+		>{{content}}</fudis-notification
+	>`,
 });
 
 export const Notification = Template.bind({});
@@ -36,16 +41,19 @@ LinkNotification.args = {
 	linkTitle: 'example',
 	link: 'https://www.example.com',
 	externalLink: true,
-	externalLinkAriaLabel: 'Link to another page',
 };
 
 export const AllVariants: StoryFn = () => ({
-	template: `
-	<fudis-grid [align]="'start'" [width]="'md'">
-		<fudis-notification variant="warning" ariaVariantText="Warning!">Note! Please don't do this, okey?</fudis-notification>
-		<fudis-notification variant="danger" ariaVariantText="Danger!">Whoops! Some error happened.</fudis-notification>
-		<fudis-notification variant="success">You succeeded!</fudis-notification>
-		<fudis-notification variant="light">This is a totally neutral message</fudis-notification>
-	</fudis-grid>
+	template: html`
+		<fudis-grid [align]="'start'" [width]="'md'">
+			<fudis-notification [variant]="'warning'" [ariaVariantText]="'Warning!'">
+				Note! Please don't do this, okey?
+			</fudis-notification>
+			<fudis-notification [variant]="'danger'" [ariaVariantText]="'Danger!'">
+				Whoops! Some error happened.
+			</fudis-notification>
+			<fudis-notification [variant]="'success'">You succeeded!</fudis-notification>
+			<fudis-notification [variant]="'light'">This is a totally neutral message</fudis-notification>
+		</fudis-grid>
 	`,
 });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.ts
@@ -34,11 +34,6 @@ export class NotificationComponent implements OnChanges, OnInit {
 	@Input() externalLink: boolean = false;
 
 	/**
-	 * Aria-label for the external link
-	 */
-	@Input() externalLinkAriaLabel: string;
-
-	/**
 	 * Title for the link, if not defined title will be the same as link URL
 	 */
 	@Input() linkTitle: string;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/readme.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/readme.mdx
@@ -15,7 +15,7 @@ Notifications are often informative contextual notifications that cannot be clic
 
 ### Link notification
 
-Notification component property `link` accepts href address as a string. This link address is shown as default link title, but it can be changed with optinal `titleLink` property. When link referes to external site `externalLink` property should be set on true. This will add an external link icon to a link. It is recommended to use `externalLinkAriaLabel` in order describe link action to screen reader users.
+Notification component property `link` accepts href address as a string. This link address is shown as default link title, but it can be changed with optinal `linkTitle` property. When link referes to external site `externalLink` property should be set to true. This will add an external link icon with aria-label to the link.
 
 <Canvas of={NotificationStories.LinkNotification}></Canvas>
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/content-projection/content/content.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/content-projection/content/content.directive.ts
@@ -4,7 +4,6 @@ import { Directive, Input, TemplateRef } from '@angular/core';
 /**
  * A marker directive used to tag the template that will be rendered inside of components. Used in e. g. `ExpandableComponent`.
  */
-
 @Directive({ selector: '[fudisContent]' })
 export class ContentDirective {
 	constructor(public templateRef: TemplateRef<unknown>) {}
@@ -12,6 +11,9 @@ export class ContentDirective {
 	@Input({ required: true }) type: 'expandable' | 'notification' | 'form' | 'fieldset' | 'section';
 }
 
+/**
+ * Fudis Footer directives
+ */
 @Directive({ selector: '[fudisFooterLeft]' })
 export class FooterContentLeftDirective {
 	constructor(public templateRef: TemplateRef<unknown>) {}

--- a/ngx-fudis/projects/ngx-fudis/src/lib/types/miscellaneous.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/types/miscellaneous.ts
@@ -31,6 +31,10 @@ export interface FudisTranslationConfig {
 		// Text shown in dropdown options if input for a language is missing
 		MISSING: string;
 	};
+	LINK: {
+		// External link icon aria-label
+		EXTERNAL_LINK: string;
+	};
 	// Clear filter button label for screen readers
 	AUTOCOMPLETE: {
 		CLEAR: string;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/utilities/translation/translationKeys.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/utilities/translation/translationKeys.ts
@@ -8,6 +8,9 @@ export const en: FudisTranslationConfig = {
 		LANGUAGE: 'Language',
 		MISSING: 'Missing',
 	},
+	LINK: {
+		EXTERNAL_LINK: '(opens in a new tab)',
+	},
 	AUTOCOMPLETE: {
 		CLEAR: 'Clear filter',
 	},
@@ -23,6 +26,9 @@ export const fi: FudisTranslationConfig = {
 	INPUT_WITH_LANGUAGE_OPTIONS: {
 		LANGUAGE: 'Kieli',
 		MISSING: 'Puuttuu',
+	},
+	LINK: {
+		EXTERNAL_LINK: '(aukeaa uuteen välilehteen)',
 	},
 	AUTOCOMPLETE: {
 		CLEAR: 'Tyhjennä valinta',
@@ -42,6 +48,9 @@ export const sv: FudisTranslationConfig = {
 	},
 	AUTOCOMPLETE: {
 		CLEAR: 'Radera val',
+	},
+	LINK: {
+		EXTERNAL_LINK: '(öppnas i en ny flik)',
 	},
 	ICON: {
 		ATTENTION: 'Observera',


### PR DESCRIPTION
Figma-kuvien mukaan Funidatan logon pitäisi olla aina näkyvissä (ei pelkästään silloin kun on annettu sisältöä contentLeftille), joten muutin contentLeft paikkaa templassa.

Refaktoroin external linkin aria-labelin käyttämään sisäistä käännösavainta, koska sen tulisi aina olla sama (käännösavainta ja käännöksiä saa muokata jos tarpeen). 
Saman voisi mielestäni tehdä footerin `logoAltText`lle, mutta jätin vielä tekemättä, koska en ollut varma onko siihen joku syy, että se tulisi aina erikseen määritellä.

Testeissä loin mockComponentin, jonka sisältöä testataan. En tiedä voisiko testit tehdä jotenkin joustavammin, nyt on vähän köpönen.