### PR TITLE
DS-192: Add initial focus to form components

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/autocomplete/autocomplete.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/autocomplete/autocomplete.component.html
@@ -10,8 +10,8 @@
 	</fudis-label>
 	<div class="fudis-autocomplete__input-wrapper">
 		<input
+			#inputRef
 			[attr.aria-invalid]="(control.touched && control.invalid) || (control.touched && invalidState) ? true : null"
-			#fudisAutocompleteInput
 			class="fudis-autocomplete__input"
 			[id]="_id"
 			[class.fudis-autocomplete__input--invalid]="(control.invalid && control.touched) || invalidState"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/autocomplete/autocomplete.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/autocomplete/autocomplete.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, Component, ElementRef, Input, OnChanges, OnInit, ViewChild, effect } from '@angular/core';
+import { AfterContentInit, AfterViewInit, Component, Input, OnChanges, OnInit, effect } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 import { FormControl, Validators } from '@angular/forms';
@@ -13,7 +13,10 @@ import { FudisTranslationService } from '../../../utilities/translation/translat
 	templateUrl: './autocomplete.component.html',
 	styleUrls: ['./autocomplete.component.scss'],
 })
-export class AutocompleteComponent extends InputBaseDirective implements OnInit, AfterContentInit, OnChanges {
+export class AutocompleteComponent
+	extends InputBaseDirective
+	implements OnInit, AfterContentInit, OnChanges, AfterViewInit
+{
 	constructor(
 		private _idService: FudisIdService,
 		_translationService: FudisTranslationService
@@ -24,8 +27,6 @@ export class AutocompleteComponent extends InputBaseDirective implements OnInit,
 			this._clearFilterText = this._translations().AUTOCOMPLETE.CLEAR;
 		});
 	}
-
-	@ViewChild('fudisAutocompleteInput') autocompleteInput: ElementRef;
 
 	/**
 	 * FormControl for the input.
@@ -71,6 +72,12 @@ export class AutocompleteComponent extends InputBaseDirective implements OnInit,
 			this._autocompleteFormControl.patchValue(this.control.value.viewValue);
 		}
 		this.checkFilteredOptions();
+	}
+
+	ngAfterViewInit(): void {
+		if (this.initialFocus) {
+			this.focusToInput();
+		}
 	}
 
 	ngOnChanges(): void {
@@ -134,7 +141,7 @@ export class AutocompleteComponent extends InputBaseDirective implements OnInit,
 		this.checkFilteredOptions();
 
 		// After clearing set focus back to input field
-		this.autocompleteInput.nativeElement.focus();
+		this.inputRef.nativeElement.focus();
 	}
 
 	/**

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox/checkbox.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox/checkbox.component.html
@@ -5,9 +5,9 @@
 			[class.fudis-checkbox__box--invalid]="(control.invalid && control.touched) || invalidState"
 			[class.fudis-checkbox__box--disabled]="control.disabled">
 			<input
+				#inputRef
 				[attr.aria-invalid]="(control.touched && control.invalid) || (control.touched && invalidState) ? true : null"
 				[formControl]="control"
-				#checkboxRef
 				[attr.aria-describedby]="_id + '_guidance'"
 				[attr.aria-label]="label"
 				type="checkbox"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox/checkbox.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox/checkbox.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewChild, ElementRef, OnInit, OnChanges } from '@angular/core';
+import { Component, Input, OnInit, OnChanges, AfterViewInit } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { InputBaseDirective } from '../../../directives/form/input-base/input-base.directive';
 
@@ -10,15 +10,13 @@ import { FudisTranslationService } from '../../../utilities/translation/translat
 	templateUrl: './checkbox.component.html',
 	styleUrls: ['./checkbox.component.scss'],
 })
-export class CheckboxComponent extends InputBaseDirective implements OnInit, OnChanges {
+export class CheckboxComponent extends InputBaseDirective implements OnInit, OnChanges, AfterViewInit {
 	constructor(
 		private _idService: FudisIdService,
 		_translationService: FudisTranslationService
 	) {
 		super(_translationService);
 	}
-
-	@ViewChild('checkboxRef') input: ElementRef;
 
 	/*
 	 * FormControl for Radio Button group
@@ -31,11 +29,17 @@ export class CheckboxComponent extends InputBaseDirective implements OnInit, OnC
 	@Input() name: string;
 
 	handleCheckboxClick(): void {
-		this.input.nativeElement.focus();
+		this.inputRef.nativeElement.focus();
 	}
 
 	ngOnInit(): void {
 		this._id = this.id ?? this._idService.getNewId('checkbox');
+	}
+
+	ngAfterViewInit(): void {
+		if (this.initialFocus) {
+			this.focusToInput();
+		}
 	}
 
 	ngOnChanges(): void {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/date-range/date-range.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/date-range/date-range.component.html
@@ -4,6 +4,7 @@
 			class="fudis-daterange__start-date"
 			[size]="'sm'"
 			[id]="_id + '-start-date'"
+			[initialFocus]="initialFocus"
 			[minDate]="startDate.minDate"
 			[maxDate]="startDate.maxDate"
 			[tooltip]="startDate.tooltip"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/date-range/date-range.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/date-range/date-range.component.ts
@@ -44,6 +44,11 @@ export class DateRangeComponent implements OnInit, AfterContentInit {
 	@Input() id: string;
 
 	/**
+	 * Set browser focus to start date input on first load.
+	 */
+	@Input() initialFocus: boolean = false;
+
+	/**
 	 * Internal id to generate unique id for Date Range
 	 */
 	protected _id: string;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.html
@@ -9,6 +9,7 @@
 		[tooltipToggle]="tooltipToggle"></fudis-label>
 	<div class="fudis-datepicker__input-wrapper">
 		<input
+			#inputRef
 			[id]="_id"
 			[formControl]="control"
 			[matDatepicker]="picker"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectorRef, Component, Input, OnChanges, OnInit, ViewEncapsulation, effect } from '@angular/core';
+import {
+	AfterViewInit,
+	ChangeDetectorRef,
+	Component,
+	Input,
+	OnChanges,
+	OnInit,
+	ViewEncapsulation,
+	effect,
+} from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';
 import { MatDatepickerIntl } from '@angular/material/datepicker';
@@ -24,7 +33,7 @@ import { updateLocale } from '../date-common/utilities';
 		{ provide: MAT_DATE_FORMATS, useValue: FUDIS_DATE_FORMATS },
 	],
 })
-export class DatepickerComponent extends InputBaseDirective implements OnInit, OnChanges {
+export class DatepickerComponent extends InputBaseDirective implements OnInit, OnChanges, AfterViewInit {
 	constructor(
 		private _idService: FudisIdService,
 		private _changeDetectorRef: ChangeDetectorRef,
@@ -69,5 +78,11 @@ export class DatepickerComponent extends InputBaseDirective implements OnInit, O
 		this._changeDetectorRef.detectChanges();
 
 		this._required = this.required ?? this.control.hasValidator(Validators.required);
+	}
+
+	ngAfterViewInit(): void {
+		if (this.initialFocus) {
+			this.focusToInput();
+		}
 	}
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/dropdown/dropdown.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/dropdown/dropdown.component.html
@@ -8,8 +8,8 @@
 		[tooltipToggle]="tooltipToggle">
 	</fudis-label>
 	<mat-select
+		#matSelect
 		[id]="_id"
-		#fudisDropdown
 		disableOptionCentering
 		[panelClass]="
 			size === 'xs' ? 'fudis-dropdown__option-list fudis-dropdown__option-list__xs' : 'fudis-dropdown__option-list'

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/dropdown/dropdown.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/dropdown/dropdown.component.ts
@@ -1,5 +1,16 @@
-import { Component, Input, ViewEncapsulation, EventEmitter, Output, OnInit, OnChanges } from '@angular/core';
+import {
+	Component,
+	Input,
+	ViewEncapsulation,
+	EventEmitter,
+	Output,
+	OnInit,
+	OnChanges,
+	AfterViewInit,
+	ViewChild,
+} from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
+import { MatSelect } from '@angular/material/select';
 import { FudisDropdownOption, FudisDropdownLanguageOption, FudisInputWidth } from '../../../types/forms';
 import { InputBaseDirective } from '../../../directives/form/input-base/input-base.directive';
 import { FudisIdService } from '../../../utilities/id-service.service';
@@ -11,13 +22,18 @@ import { FudisTranslationService } from '../../../utilities/translation/translat
 	styleUrls: ['./dropdown.component.scss'],
 	encapsulation: ViewEncapsulation.None,
 })
-export class DropdownComponent extends InputBaseDirective implements OnInit, OnChanges {
+export class DropdownComponent extends InputBaseDirective implements OnInit, OnChanges, AfterViewInit {
 	constructor(
 		private _idService: FudisIdService,
 		_translationService: FudisTranslationService
 	) {
 		super(_translationService);
 	}
+
+	/**
+	 * Template reference for input. Used in e. g. initialFocus
+	 */
+	@ViewChild('matSelect') matSelect: MatSelect;
 
 	/*
 	 * FormControl for the dropdown
@@ -62,6 +78,12 @@ export class DropdownComponent extends InputBaseDirective implements OnInit, OnC
 
 	ngOnInit(): void {
 		this._id = this.id ?? this._idService.getNewId('dropdown');
+	}
+
+	ngAfterViewInit(): void {
+		if (this.initialFocus) {
+			this.matSelect.focus();
+		}
 	}
 
 	ngOnChanges(): void {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/input-with-language-options/input-with-language-options.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/input-with-language-options/input-with-language-options.component.html
@@ -27,12 +27,13 @@
 	<ng-container *ngFor="let control of formGroup.controls | keyvalue; let index = index">
 		<fudis-text-input
 			*ngIf="control.key === _dropdownControl.value.value"
-			(handleBlur)="handleInputBlur($event, control.key)"
 			class="fudis-input-with-language-options__inputs__item"
+			(handleBlur)="handleInputBlur($event, control.key)"
 			[ariaLabel]="label + ', ' + _dropdownControl.value.viewValue"
 			[size]="'lg'"
 			[label]="label"
 			[id]="_id"
+			[initialFocus]="initialFocus && _firstLoad"
 			[required]="_requiredControls[control.key].required"
 			[invalidState]="formGroup.invalid && formGroup.touched"
 			[control]="$any(formGroup).controls[control.key]"></fudis-text-input>
@@ -49,8 +50,9 @@
 			[size]="'lg'"
 			[label]="label"
 			[id]="_id"
-			[invalidState]="formGroup.invalid && formGroup.touched"
+			[initialFocus]="initialFocus && _firstLoad"
 			[required]="_requiredControls[control.key].required"
+			[invalidState]="formGroup.invalid && formGroup.touched"
 			[control]="$any(formGroup).controls[control.key]"></fudis-text-area>
 	</ng-container>
 </ng-template>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/input-with-language-options/input-with-language-options.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/input-with-language-options/input-with-language-options.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, effect } from '@angular/core';
+import { AfterViewInit, Component, Input, OnChanges, OnInit, effect } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import {
 	FudisInputWithLanguageOptionsFormGroup,
@@ -17,7 +17,7 @@ import { FudisTranslationService } from '../../../utilities/translation/translat
 	templateUrl: './input-with-language-options.component.html',
 	styleUrls: ['./input-with-language-options.component.scss'],
 })
-export class InputWithLanguageOptionsComponent extends InputBaseDirective implements OnInit, OnChanges {
+export class InputWithLanguageOptionsComponent extends InputBaseDirective implements OnInit, OnChanges, AfterViewInit {
 	constructor(
 		private _idService: FudisIdService,
 		_translationService: FudisTranslationService
@@ -81,6 +81,11 @@ export class InputWithLanguageOptionsComponent extends InputBaseDirective implem
 	 * Fudis translation
 	 */
 	protected _languageLabel: string;
+
+	/**
+	 * If component is loaded for the first time
+	 */
+	protected _firstLoad: boolean = true;
 
 	/**
 	 * Language option dropdown value
@@ -229,5 +234,11 @@ export class InputWithLanguageOptionsComponent extends InputBaseDirective implem
 
 	ngOnChanges(): void {
 		this._updatedOptions = this._missingLanguage ? this.updateDropdownList() : this.options;
+	}
+
+	ngAfterViewInit(): void {
+		if (this._firstLoad) {
+			this._firstLoad = false;
+		}
 	}
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.html
@@ -9,11 +9,12 @@
 		[tooltipToggle]="tooltipToggle">
 	</fudis-label>
 	<textarea
-		[id]="_id"
+		#inputRef
+		class="fudis-text-area__input"
 		[formControl]="control"
 		(blur)="onBlur($event)"
-		class="fudis-text-area__input"
 		[class.fudis-text-area__input--invalid]="(control.touched && control.invalid) || invalidState"
+		[id]="_id"
 		[attr.aria-describedby]="_id + '_guidance'"
 		[attr.aria-invalid]="(control.touched && control.invalid) || (control.touched && invalidState) ? true : null"
 		[attr.minLength]="minLength"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, effect } from '@angular/core';
+import { AfterViewInit, Component, Input, OnChanges, OnInit, effect } from '@angular/core';
 
 import { FormControl, Validators } from '@angular/forms';
 import { InputBaseDirective } from '../../../directives/form/input-base/input-base.directive';
@@ -12,7 +12,7 @@ import { FudisTranslationService } from '../../../utilities/translation/translat
 	templateUrl: './text-area.component.html',
 	styleUrls: ['./text-area.component.scss'],
 })
-export class TextAreaComponent extends InputBaseDirective implements OnInit, OnChanges {
+export class TextAreaComponent extends InputBaseDirective implements OnInit, OnChanges, AfterViewInit {
 	constructor(
 		private _idService: FudisIdService,
 		_translationService: FudisTranslationService
@@ -55,5 +55,11 @@ export class TextAreaComponent extends InputBaseDirective implements OnInit, OnC
 
 	ngOnChanges(): void {
 		this._required = this.required ?? this.control.hasValidator(Validators.required);
+	}
+
+	ngAfterViewInit(): void {
+		if (this.initialFocus) {
+			this.focusToInput();
+		}
 	}
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.html
@@ -10,7 +10,7 @@
 	</fudis-label>
 	<input
 		[attr.aria-invalid]="(control.touched && control.invalid) || (control.touched && invalidState) ? true : null"
-		#fudisTextInput
+		#inputRef
 		[attr.aria-label]="ariaLabel"
 		[formControl]="control"
 		[attr.minlength]="minLength"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewChild, ElementRef, HostBinding, OnInit, OnChanges, effect } from '@angular/core';
+import { Component, Input, HostBinding, OnInit, OnChanges, effect, AfterViewInit } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { InputBaseDirective } from '../../../directives/form/input-base/input-base.directive';
 
@@ -11,7 +11,7 @@ import { FudisTranslationService } from '../../../utilities/translation/translat
 	templateUrl: './text-input.component.html',
 	styleUrls: ['./text-input.component.scss'],
 })
-export class TextInputComponent extends InputBaseDirective implements OnInit, OnChanges {
+export class TextInputComponent extends InputBaseDirective implements OnInit, OnChanges, AfterViewInit {
 	constructor(
 		private _idService: FudisIdService,
 		_translationService: FudisTranslationService
@@ -24,8 +24,6 @@ export class TextInputComponent extends InputBaseDirective implements OnInit, On
 	}
 
 	@HostBinding('class') classes = 'fudis-text-input-host';
-
-	@ViewChild('fudisTextInput') input: ElementRef<HTMLInputElement>;
 
 	/**
 	 * FormControl for text-input
@@ -73,5 +71,11 @@ export class TextInputComponent extends InputBaseDirective implements OnInit, On
 
 	ngOnChanges(): void {
 		this._required = this.required ?? this.control.hasValidator(Validators.required);
+	}
+
+	ngAfterViewInit(): void {
+		if (this.initialFocus) {
+			this.focusToInput();
+		}
 	}
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/input-base/input-base.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/input-base/input-base.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, EventEmitter, Output, Signal, effect } from '@angular/core';
+import { Directive, Input, EventEmitter, Output, Signal, effect, ViewChild, ElementRef } from '@angular/core';
 
 import { FudisFormErrors } from '../../../types/forms';
 import { TooltipApiDirective } from '../../tooltip/tooltip-api.directive';
@@ -18,6 +18,11 @@ export class InputBaseDirective extends TooltipApiDirective {
 			this._requiredText = this._translations().REQUIRED;
 		});
 	}
+
+	/**
+	 * Template reference for input. Used in e. g. initialFocus
+	 */
+	@ViewChild('inputRef') inputRef: ElementRef;
 
 	/**
 	 * Label for input.
@@ -61,6 +66,11 @@ export class InputBaseDirective extends TooltipApiDirective {
 	@Input() required: boolean | undefined = undefined;
 
 	/**
+	 * Set browser focus to input on first load.
+	 */
+	@Input() initialFocus: boolean = false;
+
+	/**
 	 * To listen for input's blur event.
 	 */
 	@Output() handleBlur: EventEmitter<Event> = new EventEmitter<Event>();
@@ -85,7 +95,20 @@ export class InputBaseDirective extends TooltipApiDirective {
 	 */
 	protected _required: boolean = false;
 
+	private _focusTryCounter: number = 0;
+
 	public onBlur(event: Event): void {
 		this.handleBlur.emit(event);
+	}
+
+	focusToInput(): void {
+		if (this.inputRef?.nativeElement) {
+			this.inputRef.nativeElement.focus();
+		} else if (this._focusTryCounter < 100) {
+			setTimeout(() => {
+				this._focusTryCounter += 1;
+				this.focusToInput();
+			}, 100);
+		}
 	}
 }


### PR DESCRIPTION
Lisätty "initialFocus" @Input-direktiivi peruslomakekomponenteille, jolla voidaan siirtää kohdistus kenttään, kun komponentti ladataan ensimmäisen kerran kälissä.

https://jira.funidata.fi/browse/DS-192