### PR TITLE
DS-198: Adjust minWidth of grid items

### DIFF
--- a/ngx-fudis/projects/dev/src/app/app.component.html
+++ b/ngx-fudis/projects/dev/src/app/app.component.html
@@ -2,6 +2,7 @@
 	<div class="root-style">
 		<fudis-grid>
 			<fudis-heading [level]="1" [size]="'xl'">Welcome to Fudis sandbox </fudis-heading>
+
 			<fudis-notification variant="danger" ariaVariantText="Varoitus!"
 				>Whoops! Here is danger notification.</fudis-notification
 			>
@@ -33,7 +34,7 @@
 					<fudis-dropdown-menu-item [label]="'Item 878787878571'"></fudis-dropdown-menu-item>
 				</fudis-dropdown-menu>
 			</fudis-button>
-
+			<app-dropdown-examples fudisGridItem [columns]="'stretch'" />
 			<app-form-examples fudisGridItem [columns]="'stretch'" />
 
 			<fudis-expandable [title]="'Description list'">

--- a/ngx-fudis/projects/dev/src/app/app.module.ts
+++ b/ngx-fudis/projects/dev/src/app/app.module.ts
@@ -11,9 +11,16 @@ import { DialogTestComponent } from './dialog-test/dialog-test.component';
 import { DialogTestContentComponent } from './dialog-test/dialog-test-content/dialog-test-content.component';
 import { TranslocoRootModule } from './transloco-root.module';
 import { AppFormExampleComponent } from './components/formExamples.component';
+import { AppDropdownExamplesComponent } from './components/dropdownExamples.component';
 
 @NgModule({
-	declarations: [AppComponent, DialogTestComponent, DialogTestContentComponent, AppFormExampleComponent],
+	declarations: [
+		AppComponent,
+		DialogTestComponent,
+		DialogTestContentComponent,
+		AppFormExampleComponent,
+		AppDropdownExamplesComponent,
+	],
 	imports: [
 		BrowserModule,
 		BrowserAnimationsModule,

--- a/ngx-fudis/projects/dev/src/app/components/dropdownExamples.component.html
+++ b/ngx-fudis/projects/dev/src/app/components/dropdownExamples.component.html
@@ -1,0 +1,16 @@
+<fudis-expandable [title]="'Dropdown examples'">
+	<ng-template fudisContent type="expandable">
+		<fudis-grid [width]="'sm'" [columns]="2">
+			<fudis-dropdown
+				[control]="testFormGroup.controls.dropdownFirst"
+				[options]="_options"
+				[multipleOption]="true"
+				[label]="'First dropdown'" />
+			<fudis-dropdown
+				[control]="testFormGroup.controls.dropdownSecond"
+				[options]="_options"
+				[multipleOption]="true"
+				[label]="'Second dropdown'" />
+		</fudis-grid>
+	</ng-template>
+</fudis-expandable>

--- a/ngx-fudis/projects/dev/src/app/components/dropdownExamples.component.ts
+++ b/ngx-fudis/projects/dev/src/app/components/dropdownExamples.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { FudisDropdownOption } from 'dist/ngx-fudis/lib/types/forms';
+
+type MyForm = {
+	dropdownFirst: FormControl<FudisDropdownOption[] | null>;
+	dropdownSecond: FormControl<FudisDropdownOption[] | null>;
+};
+
+@Component({
+	selector: 'app-dropdown-examples',
+	templateUrl: 'dropdownExamples.component.html',
+})
+export class AppDropdownExamplesComponent {
+	testFormGroup = new FormGroup<MyForm>({
+		dropdownFirst: new FormControl<FudisDropdownOption[] | null>(null),
+		dropdownSecond: new FormControl<FudisDropdownOption[] | null>(null),
+	});
+
+	_options = [
+		{ value: '123', viewValue: 'This is really long option, to see what is happening' },
+		{ value: '124', viewValue: 'Shorter option' },
+	];
+}

--- a/ngx-fudis/projects/dev/src/app/components/formExamples.component.html
+++ b/ngx-fudis/projects/dev/src/app/components/formExamples.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t">
-	<fudis-expandable [title]="'Form with some transloco'" [closed]="false">
+	<fudis-expandable [title]="'Form with some transloco'" [closed]="true">
 		<ng-template fudisActions type="expandable">
 			<fudis-button [label]="'Submit!'" (handleClick)="clickSubmit()"></fudis-button>
 		</ng-template>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid/grid.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid/grid.component.scss
@@ -11,6 +11,10 @@
 	grid-template-rows: auto 1fr;
 	grid-template-columns: auto 1fr;
 
+	> * {
+		min-width: 0;
+	}
+
 	@include breakpoints.breakpoint('sm') {
 		width: 100%;
 	}

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/grid/grid-api/grid-api.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/grid/grid-api/grid-api.directive.ts
@@ -14,25 +14,9 @@ import { FudisSpacing } from '../../../types/miscellaneous';
 })
 export class GridApiDirective {
 	/**
-	 * Maximum width of Grid. When viewport gets narrower, grid automatically adjusts to lower sizes.
-	 * xxl = Default value. Viewports of 1600px and larger
-	 * xl = Viewports smaller than 1600px
-	 * lg = Viewports smaller than 1200px
-	 * md = Viewports smaller than 992px
-	 * sm = Viewports smaller than 768px
-	 * xs = Viewports smaller than 576px
-	 */
-	@Input() width: FudisGridWidth;
-
-	/**
 	 * Alignment of Grid component inside its parent
 	 */
 	@Input() align: FudisGridAlign;
-
-	/**
-	 * Vertical alignment of Grid Items in a row
-	 */
-	@Input() alignItemsY: FudisGridAlignItems;
 
 	/**
 	 * Horizontal alignment of Grid Items in a row
@@ -40,19 +24,9 @@ export class GridApiDirective {
 	@Input() alignItemsX: FudisGridAlignItems;
 
 	/**
-	 * Margin top for the Grid
+	 * Vertical alignment of Grid Items in a row
 	 */
-	@Input() marginTop: FudisSpacing;
-
-	/**
-	 * Margin bottom for the Grid
-	 */
-	@Input() marginBottom: FudisSpacing;
-
-	/**
-	 * Horizontal margins left and right of the grid
-	 */
-	@Input() marginSides: FudisGridMarginSide;
+	@Input() alignItemsY: FudisGridAlignItems;
 
 	/**
 	 * Custom CSS classes for Grid element
@@ -63,16 +37,6 @@ export class GridApiDirective {
 	 * Grid column gap. Using Fudis spacing token values of xxs to xxl and 0.
 	 */
 	@Input() columnGap: FudisGridGap;
-
-	/**
-	 * Grid row gap. Using Fudis spacing token values of xxs to xxl and 0.
-	 */
-	@Input() rowGap: FudisGridGap;
-
-	/**
-	 * To make Grid ignore default values defined by application and FudisGridService
-	 */
-	@Input() ignoreDefaults: boolean = false;
 
 	/**
 	 * Setting of columns for the grid. Input will be converted to native CSS grid grid-template-columns values
@@ -86,4 +50,40 @@ export class GridApiDirective {
 	 * And after xl breakpoint 'repeat(3, 1fr)'
 	 */
 	@Input() columns: string | number | FudisGridColumnsResponsive;
+
+	/**
+	 * To make Grid ignore default values defined by application and FudisGridService
+	 */
+	@Input() ignoreDefaults: boolean = false;
+
+	/**
+	 * Margin bottom for the Grid
+	 */
+	@Input() marginBottom: FudisSpacing;
+
+	/**
+	 * Horizontal margins left and right of the grid
+	 */
+	@Input() marginSides: FudisGridMarginSide;
+
+	/**
+	 * Margin top for the Grid
+	 */
+	@Input() marginTop: FudisSpacing;
+
+	/**
+	 * Grid row gap. Using Fudis spacing token values of xxs to xxl and 0.
+	 */
+	@Input() rowGap: FudisGridGap;
+
+	/**
+	 * Maximum width of Grid. When viewport gets narrower, grid automatically adjusts to lower sizes.
+	 * xxl = Default value. Viewports of 1600px and larger
+	 * xl = Viewports smaller than 1600px
+	 * lg = Viewports smaller than 1200px
+	 * md = Viewports smaller than 992px
+	 * sm = Viewports smaller than 768px
+	 * xs = Viewports smaller than 576px
+	 */
+	@Input() width: FudisGridWidth;
 }


### PR DESCRIPTION
https://jira.funidata.fi/browse/DS-198

Bug mentioned in the ticket seems to be caused by ngMaterial, as it stretches elements too wide and we don't have feasible way to restrict that.

Problem should diminish if we refactor ngMaterial dropdowns away to use our own components and subcomponents. Meanwhile this fix should not cause other arm elsewhere.