### PR TITLE
Require CLA acceptance in PR's from outside collaborators

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,36 @@
+name: CLA Assistant
+on:
+  issue_comment:
+    types:
+      - created
+  # DANGER! See our internal documentation and https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ before you modify anything.
+  pull_request_target:
+    types:
+      - opened
+      - closed
+      - synchronize
+
+permissions:
+  actions: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    name: Require CLA from outside collaborators
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run CLA Assistant Action
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURE_STORE_TOKEN }}
+        with:
+          path-to-signatures: "fudis_cla_v1_signatures.json"
+          path-to-document: "https://github.com/funidata/fudis/CLA"
+          branch: "main"
+          # Add users here to bypass CLA requirements (teams/orgs not supported).
+          allowlist: "dependabot[bot],videoeero,RiinaKuu,xanxan,Aleksuo,MayaMarjut"
+          remote-organization-name: funidata
+          remote-repository-name: cla-signature-store

--- a/CLA
+++ b/CLA
@@ -1,0 +1,33 @@
+Funidata Oy
+
+CONTRIBUTOR LICENSE AGREEMENT
+
+Thank you for your interest in the development of software of Funidata Oy ("Funidata"). You are willing to submit certain software source code and related intellectual property rights and possible related documentation to Funidata for use by Funidata in its software projects and/or products ("Contribution").
+
+Before Funidata can accept your Contribution, you need to enter into this Contributor License Agreement ("CLA"), which grants Funidata the required licenses to utilize Contribution in its projects and products. You can do so by click-accepting this CLA, or if such option is not provided, by signing this CLA and returning the signed CLA to Funidata.
+
+1 LICENSE GRANT
+
+1.1 Subject to the terms and conditions of this CLA, you hereby grant Funidata and any recipients of software distributed by Funidata:
+
+(i) with respect to any copyrighted material you own or otherwise have sufficient rights to license, a worldwide, royalty-free, perpetual, fully paid-up and irrevocable license, which includes the right to grant or transfer licenses or sublicenses to third parties, to reproduce, modify, prepare derivative works of, publicly display and otherwise distribute Contribution and derivative works thereof; and
+
+(ii) with respect to any patents you own or otherwise have sufficient rights to license and which are necessarily infringed by the use of Contribution as set out herein, a worldwide, royalty-free, perpetual, fully paid-up and irrevocable license to make, have made, use, offer to sell, sell, import and otherwise transfer Contribution in whole or in part and alone or in combination with other material.
+
+1.2 Funidata reserves the right (and you grant Funidata the unrestricted right with respect to Contribution) to license Contribution or the software to which Contribution is a part of, under a license of Funidata's choosing, including copyleft, permissive, commercial or proprietary license.
+
+1.3 Subject to provisions of applicable mandatory law, and unless otherwise set out in this CLA or elsewhere agreed between you and Funidata, Contribution is provided by you on an "as is" basis without warranties of any kind.
+
+2 YOUR RIGHTS AND OBLIGATIONS
+
+2.1 The licenses granted to Funidata above in Section 1.1 are non-exclusive, meaning that you can also grant licenses to Contribution to third parties or use Contribution by yourself. However, you agree to inform Funidata in writing before you license Contribution to any third party or you use the Contribution commercially yourself (including if you have done so prior to signing of this CLA).
+
+2.2 You represent and warrant that you are legally entitled to grant the above rights and licenses in Contribution to Funidata and that you are not aware that the use of Contribution by Funidata would infringe third-party intellectual property rights. If the Contribution is not your original creation as a whole, you agree to inform Funidata in writing of the original creator of the Contribution or parts thereof and the extent of your license before submitting Contribution.
+
+2.3 You agree to promptly notify Funidata in writing of any other facts or circumstances of which you become aware that would make the above representations inaccurate in any respect or which otherwise may affect this CLA or Funidata's use of Contribution in its projects or products.
+
+3 MISCELLANEOUS
+
+3.1 You may not assign this CLA to any third party without Funidata's prior written approval. As a main rule, each individual contributor must sign their own CLA with Funidata. Funidata may assign its rights and obligations hereunder in whole or in part to a third party.
+
+3.2 This CLA is governed by the laws of Finland excluding its choice of law provisions and the United Nations Convention on the International Sale of Goods. Unless otherwise provided in the mandatory provisions of applicable law, all disputes concerning this CLA shall be settled as a first instance before the District Court of Helsinki, Finland.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Versioned documentation is also deployed for pull requests whenever their branch
 
 ## Contributions
 
-Contributions are welcome. If you are insterested in contributing to Fudis, please get in touch with the maintainers first to sort out the necessary CLA.
+Contributions from outside collaborators are welcome. When you open a pull request for the first time, our CLA Assistant bot will ask you to accept our [Contributor License Agreement](./CLA).
+
+If you work for Funidata and the CLA check does not pass for your PR, make sure your name is on the allowlist in [cla.yaml](.github/workflows/cla.yaml). You do not need to sign the CLA.
 
 ## License
 


### PR DESCRIPTION
- Uses CLA Assistant action for managing signatures and checking PR's.
- Stores signatures in a private repository.
- Funidata employees must be added to `allowlist` in `.github/workflows/cla.yaml`.
- See our internal documentation for more.