### PR TITLE
[IMPROVEMENT / Autocomplete single & multiselect]: Add placeholder prop

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/autocomplete-multi-select/autocomplete-multi-select.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/autocomplete-multi-select/autocomplete-multi-select.component.html
@@ -12,14 +12,15 @@
 	<div class="fudis-autocomplete-multi-select__input-wrapper">
 		<input
 			#autocompleteInput
+			role="combobox"
+			class="fudis-autocomplete-multi-select__input-wrapper__input"
 			(focus)="_openDropdown()"
 			(keyup)="_doSearch($event)"
 			(keydown)="_closeOnShiftTab($event)"
 			[id]="_id"
 			[value]="_filterText"
-			role="combobox"
+			[attr.placeholder]="placeholder ? placeholder : null"
 			[attr.aria-expanded]="_toggleOn"
-			class="fudis-autocomplete-multi-select__input-wrapper__input"
 			[attr.aria-labelledby]="_id + '-selected-items'"
 			[attr.aria-describedby]="_id + '_guidance'" />
 		<fudis-button

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/autocomplete-multi-select/autocomplete-multi-select.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/autocomplete-multi-select/autocomplete-multi-select.component.ts
@@ -57,6 +57,11 @@ export class AutocompleteMultiSelectComponent extends InputBaseDirective impleme
 	@Input() selectedOptions: FudisDropdownOption[] = [];
 
 	/**
+	 * Placeholder text in input when selection is not yet made
+	 */
+	@Input() placeholder: string;
+
+	/**
 	 * Output for option click
 	 */
 	@Output() optionChange = new EventEmitter<FudisDropdownOption[]>();

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/autocomplete-multi-select/autocomplete-multi-select.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/autocomplete-multi-select/autocomplete-multi-select.stories.ts
@@ -72,6 +72,7 @@ AutocompleteMultiSelect.args = {
 	label: 'Autocomplete multi-select label',
 	helpText: 'Guidance text for autocomplete multi-select. Selected filter items should be above this guidance text.',
 	tooltip: 'With this multi-select you can choose unlimited number of filters for your search',
+	placeholder: 'Search and select options',
 	options: manyOptions,
 };
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/autocomplete/autocomplete.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/autocomplete/autocomplete.component.html
@@ -11,18 +11,19 @@
 	<div class="fudis-autocomplete__input-wrapper">
 		<input
 			#inputRef
-			[attr.aria-invalid]="(control.touched && control.invalid) || (control.touched && invalidState) ? true : null"
 			class="fudis-autocomplete__input"
-			[id]="_id"
 			[class.fudis-autocomplete__input--invalid]="(control.invalid && control.touched) || invalidState"
 			[class.fudis-autocomplete__input--disabled]="disabled"
 			type="text"
+			[id]="_id"
+			[matAutocomplete]="autocomplete"
 			(blur)="_autocompleteBlur($event)"
 			[formControl]="_autocompleteFormControl"
-			[matAutocomplete]="autocomplete"
-			[attr.aria-describedby]="_id + '_guidance'"
 			[readonly]="disabled"
+			[attr.aria-describedby]="_id + '_guidance'"
+			[attr.aria-invalid]="(control.touched && control.invalid) || (control.touched && invalidState) ? true : null"
 			[attr.aria-disabled]="disabled"
+			[attr.placeholder]="placeholder ? placeholder : null"
 			[attr.required]="_required ? true : null" />
 		<ng-container *ngIf="_autocompleteFormControl.value">
 			<fudis-button

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/autocomplete/autocomplete.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/autocomplete/autocomplete.component.ts
@@ -55,6 +55,11 @@ export class AutocompleteComponent
 	@Input() variant: 'search' | 'dropdown' = 'search';
 
 	/**
+	 * Placeholder text in input when selection is not yet made
+	 */
+	@Input() placeholder: string;
+
+	/**
 	 * Internal formControl to check if typed text matches with any of the options' viewValue
 	 */
 	protected _autocompleteFormControl = new FormControl<string | null>('');

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/autocomplete/autocomplete.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/autocomplete/autocomplete.stories.ts
@@ -39,6 +39,7 @@ AutocompleteSearch.args = {
 		{ value: 'very-long-value', viewValue: 'Brian Eggplant with Marinated Pomegranate Seeds' },
 		{ value: 1234, viewValue: 'Martin Seeding' },
 	],
+	placeholder: "Try searching for 'Mary'",
 	tooltip: 'Tooltip text for autocomplete',
 	tooltipPosition: 'below',
 	tooltipToggle: true,
@@ -60,6 +61,7 @@ AutocompleteDropdown.args = {
 	errorMsg: { required: 'This selection is required' },
 	options: manyOptions,
 	tooltip: 'Tooltip text for autocomplete',
+	placeholder: 'Focus here to expand options!',
 	tooltipPosition: 'below',
 	tooltipToggle: true,
 };

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.html
@@ -5,7 +5,7 @@
 				<fudis-icon class="fudis-error-summary__icon" [icon]="'alert'"></fudis-icon>
 				<div class="fudis-error-summary__errors">
 					<ng-container *ngIf="helpText">
-						<fudis-body-text class="fudis-error-summary__errors__help-text">
+						<fudis-body-text fudisSpacing [marginTop]="'xs'">
 							<span class="fudis-visually-hidden">{{ _attentionText }}:&nbsp;</span>
 							{{ helpText }}</fudis-body-text
 						>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.scss
@@ -21,12 +21,6 @@
 		margin-top: spacing.$spacing-xs;
 	}
 
-	&__errors {
-		&__help-text {
-			margin-top: spacing.$spacing-xs;
-		}
-	}
-
 	&__error-list {
 		@include utilities.box-reset;
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.component.scss
@@ -8,9 +8,7 @@
 }
 
 .fudis-body-text {
-	box-sizing: border-box;
-	margin-top: 0;
-	padding: 0;
+	@include utilities.box-reset;
 
 	&__default {
 		@include colorMixins.text-color('gray-dark');


### PR DESCRIPTION
From feedback requests:
- Add placeholder `@Input` to Autocomplete Multiselect [(Slack-thread)](https://sisudev.slack.com/archives/C04NE2ZPZST/p1695996448795909)
- Add placeholder `@Input` to Autocomplete Singleselect [(Slack-thread)](https://sisudev.slack.com/archives/C04NE2ZPZST/p1695996448795909)
- Fix margin bug in Notification by resetting margins in BodyText [(Slack-thread)](https://sisudev.slack.com/archives/C03G46K6LG1/p1696233432331349)