### PR TITLE
[BadgeComponent]: Add CSS display

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/badge/badge.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/badge/badge.component.scss
@@ -8,6 +8,7 @@
 	@include typography.badge-typography;
 	@include colorMixin.text-color('gray-dark');
 
+	display: inline-block;
 	padding: spacing.$pixel-1 spacing.$pixel-3;
 	vertical-align: middle;
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/foundations/spacing/tokens.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/foundations/spacing/tokens.scss
@@ -22,7 +22,6 @@ $pixel-tokens: (
 	'2px': $pixel-2,
 	'3px': $pixel-3,
 );
-
 $spacing-input-xs: calc(4rem / var(--fudis-rem-multiplier));
 $spacing-input-sm: calc(10rem / var(--fudis-rem-multiplier));
 $spacing-input-md: calc(14rem / var(--fudis-rem-multiplier));


### PR DESCRIPTION
https://sisudev.slack.com/archives/C04NE2ZPZST/p1697462182558299

Badge split in to two rows in small screen. Fixed by adding `display: inline-block;`