### PR TITLE
[Alert Group]: Initiate aria-label only when there are 1 or more alert present

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/alert/alert-group/alert-group.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/alert/alert-group/alert-group.component.html
@@ -1,7 +1,7 @@
 <section
 	*ngIf="_visible"
 	class="fudis-alert-group fudis-alert-group__{{ position }}"
-	[attr.aria-label]="_alertGroupLabel + ': ' + _alertList().length">
+	[attr.aria-label]="_alertList().length > 0 ? _alertGroupLabel + ': ' + _alertList().length : null">
 	<ng-container *ngFor="let alert of _alertList()">
 		<fudis-alert
 			[initialFocus]="alert.initialFocus"


### PR DESCRIPTION
Alert Group's `aria-label` was present always, even if there were zero alerts to inform about. 
Let's initiate _"Notifications - number of notifications: 0"_ only when there are 1 or more alert present.