### PR TITLE
[Link]: Change color to primary-dark

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/link/link.component.scss
@@ -12,7 +12,7 @@
 		}
 
 		&__primary {
-			@include colors.text-color('primary');
+			@include colors.text-color('primary-dark');
 		}
 
 		&__default {


### PR DESCRIPTION
Change fudis-link color to `primary-color-dark` as in Sisu.
Change is communicated with designers.