### PR TITLE
[Dialog]: Add dialog size 'xl'

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.scss
@@ -47,6 +47,10 @@
         width: calc(gridTokens.$grid-width-lg + 2 * spacing.$spacing-xl);
       }
     }
+
+    &__xl {
+      width: gridTokens.$grid-width-xl;
+    }
   }
 
   @include breakpoints.breakpoint("sm") {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.spec.ts
@@ -5,6 +5,7 @@ import { ButtonComponent } from '../button/button.component';
 import { DialogComponent } from './dialog.component';
 import { FudisDialogService } from '../../services/dialog/dialog.service';
 import { AlertGroupComponent } from '../alert/alert-group/alert-group.component';
+import { getElement } from '../../utilities/tests/utilities';
 
 describe('DialogComponent', () => {
   let component: DialogComponent;
@@ -29,26 +30,47 @@ describe('DialogComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should have correct size attribute', () => {
-    expect(component.size).toBe('md');
+  describe('HTML attributes', () => {
+    it('should have CSS classes according to given size Input', () => {
+      const dialogEl = getElement(fixture, '.fudis-dialog');
+      component.ngOnInit();
 
-    component.size = 'sm';
-    fixture.detectChanges();
-    component.ngOnInit();
+      expect(component.size).toEqual('md');
+      expect(dialogEl.className).toEqual('fudis-dialog fudis-dialog__size__md');
 
-    expect(component.size).toBe('sm');
+      component.size = 'sm';
+      fixture.detectChanges();
+      component.ngOnInit();
 
-    component.size = 'lg';
-    fixture.detectChanges();
-    component.ngOnInit();
+      expect(dialogEl.className).toEqual('fudis-dialog fudis-dialog__size__sm');
 
-    expect(component.size).toBe('lg');
+      component.size = 'lg';
+      fixture.detectChanges();
+      component.ngOnInit();
 
-    component.size = 'initial';
-    fixture.detectChanges();
-    component.ngOnInit();
+      expect(dialogEl.className).toEqual('fudis-dialog fudis-dialog__size__lg');
 
-    expect(component.size).toBe('initial');
+      component.size = 'xl';
+      fixture.detectChanges();
+      component.ngOnInit();
+
+      expect(dialogEl.className).toEqual('fudis-dialog fudis-dialog__size__xl');
+
+      component.size = 'initial';
+      fixture.detectChanges();
+      component.ngOnInit();
+
+      expect(dialogEl.className).toEqual('fudis-dialog fudis-dialog__size__initial');
+    });
+
+    it('should have CSS class for close button', () => {
+      component.closeButtonPositionAbsolute = true;
+      fixture.detectChanges();
+
+      const closeButtonEl = getElement(fixture, '.fudis-dialog fudis-button');
+
+      expect(closeButtonEl.className).toEqual('fudis-dialog__close fudis-dialog__close__absolute');
+    });
   });
 
   it('should call open signal on initialisation', () => {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.ts
@@ -3,7 +3,7 @@ import { FudisDialogService } from '../../services/dialog/dialog.service';
 import { FudisIdService } from '../../services/id/id.service';
 import { FudisTranslationService } from '../../services/translation/translation.service';
 
-type DialogSize = 'sm' | 'md' | 'lg' | 'initial';
+type DialogSize = 'sm' | 'md' | 'lg' | 'xl' | 'initial';
 
 @Component({
   selector: 'fudis-dialog',

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.stories.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line max-classes-per-file
 import { Component, OnInit, TemplateRef } from '@angular/core';
 import { StoryFn, Meta, moduleMetadata } from '@storybook/angular';
 import { FormControl, FormGroup, ReactiveFormsModule, FormsModule } from '@angular/forms';
@@ -15,7 +14,7 @@ type TestForm = {
 
 @Component({
   selector: 'example-dialog-content',
-  template: `<fudis-dialog [size]="'lg'">
+  template: `<fudis-dialog [size]="'xl'">
     <fudis-heading fudisDialogTitle [level]="2"
       >Dialog with fudis-grid and scrollable content</fudis-heading
     >

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/ngMaterial-theme.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/ngMaterial-theme.scss
@@ -84,9 +84,17 @@
     @include borders.border("2px", "solid", "gray-dark");
 
     max-width: 90vw !important;
+
+    &:has(.fudis-dialog__size__xl) {
+      max-width: 98vw !important;
+    }
   }
 
   @include breakpoints.breakpoint("md") {
     max-width: 80vw !important;
+
+    &:has(.fudis-dialog__size__xl) {
+      max-width: 98vw !important;
+    }
   }
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/readme.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/readme.mdx
@@ -23,12 +23,14 @@ Fudis Dialog consists of three parts: service, component and directives.
 Fudis Dialog Service provides tools for opening and closing a dialog. Service accepts both Angular components and templates to be passed as an argument.
 
 Dialog is opened with `dialogService.open()` which takes either an Angular component or reference to a template as an argument. Dialog is closed with `dialogService.close()`.
+As a feature, dialog has close icon button on the right corner of the dialog which cannot be removed.
 
 ### Component
 
 Dialog component is a wrapper component taking one parameter: `size`.
 
-Size determines the horizontal size of the dialog. Available options are `sm`, `md`, `lg` and `initial`. If none is given it defaults to `md`.
+Size determines the horizontal size of the dialog. Available options are `sm`, `md`(default), `lg`, `xl` and `initial`.
+`lg` and `xl` are initially the same size but `xl` will hold its width as long as possible and has bigger max-width on small screen widths.
 
 ```
 <fudis-dialog [size]="'sm'">


### PR DESCRIPTION
Added new `size` option `xl` for Dialog component.

This was a request from development team.

Note that `xl` is initially the same size as `lg` but `xl` will hold its width longer, therefore it's wider in smaller screens.
[Figma designs](https://www.figma.com/file/kqoga9Si2O2KmUDGVcpBep/HRP-353-Harjoitteluraportit?type=design&node-id=133-7021&mode=design&t=tvUUmhGkzGXM8JtV-0) were 1100px wide and tried to follow them as closely as possible --> both `lg` and `xl` are 1120px when most widest.
