### PR TITLE
[InputBaseDirective, FieldsetBaseDirective]: Unit tests

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.html
@@ -15,6 +15,7 @@
     [formControl]="control"
     (blur)="onBlur($event)"
     [class.fudis-form-input--invalid]="(control.touched && control.invalid) || invalidState"
+    [class.fudis-form-input--disabled]="disabled"
     [id]="id"
     [attr.aria-describedby]="id + '_guidance'"
     [attr.aria-invalid]="
@@ -23,6 +24,8 @@
     [attr.minLength]="minLength"
     [attr.maxLength]="maxLength"
     [attr.required]="_required ? true : null"
+    [attr.aria-disabled]="disabled"
+    [readonly]="disabled"
   >
   </textarea>
   <fudis-guidance

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.stories.ts
@@ -24,14 +24,18 @@ import { FudisValidators } from '../../../utilities/form/validators';
         [tooltip]="'I am here to give you additional guidance'"
         [tooltipPosition]="'right'"
         [tooltipToggle]="false"
-      >
-      </fudis-text-area>
+        />
       <fudis-text-area
         [control]="secondTextAreaControl"
         [label]="'Required Text Area with max and min character length'"
         [helpText]="'This is an example Text Area with multiple validations.'"
-      >
-      </fudis-text-area>
+        />
+      <fudis-text-area
+        [control]="thirdTextAreaControl"
+        [label]="'Disabled text area'"
+        [helpText]="'You should be able to focus on this text-area but not insert any values'"
+        [disabled]="true"
+        />
     </form>
   `,
 })
@@ -56,6 +60,8 @@ class TextAreaWithFormControlExampleComponent {
   ]);
 
   secondTextAreaControl: FormControl = new FormControl('', this.validatorsForSecondTextInput);
+
+  thirdTextAreaControl: FormControl = new FormControl('', FudisValidators.minLength(20, 'Write at least 20 characters'));
 
   mainFormGroup: FormGroup = this._formBuilder.group({
     firstTextAreaControl: this.firstTextAreaControl,

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.stories.ts
@@ -24,18 +24,18 @@ import { FudisValidators } from '../../../utilities/form/validators';
         [tooltip]="'I am here to give you additional guidance'"
         [tooltipPosition]="'right'"
         [tooltipToggle]="false"
-        />
+      />
       <fudis-text-area
         [control]="secondTextAreaControl"
         [label]="'Required Text Area with max and min character length'"
         [helpText]="'This is an example Text Area with multiple validations.'"
-        />
+      />
       <fudis-text-area
         [control]="thirdTextAreaControl"
         [label]="'Disabled text area'"
         [helpText]="'You should be able to focus on this text-area but not insert any values'"
         [disabled]="true"
-        />
+      />
     </form>
   `,
 })
@@ -61,7 +61,10 @@ class TextAreaWithFormControlExampleComponent {
 
   secondTextAreaControl: FormControl = new FormControl('', this.validatorsForSecondTextInput);
 
-  thirdTextAreaControl: FormControl = new FormControl('', FudisValidators.minLength(20, 'Write at least 20 characters'));
+  thirdTextAreaControl: FormControl = new FormControl(
+    '',
+    FudisValidators.minLength(20, 'Write at least 20 characters'),
+  );
 
   mainFormGroup: FormGroup = this._formBuilder.group({
     firstTextAreaControl: this.firstTextAreaControl,

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.html
@@ -25,8 +25,11 @@
     [id]="id"
     [attr.type]="type"
     [class.fudis-form-input--invalid]="(control.touched && control.invalid) || invalidState"
+    [class.fudis-form-input--disabled]="disabled"
     [attr.aria-describedby]="id + '_guidance'"
     [attr.required]="_required ? true : null"
+    [attr.aria-disabled]="disabled"
+    [readonly]="disabled"
   />
   <fudis-guidance
     *ngIf="!disableGuidance"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.stories.ts
@@ -54,6 +54,12 @@ import { FudisValidators } from '../../../utilities/form/validators';
         [type]="'number'"
         [size]="'sm'"
       />
+      <fudis-text-input
+        [control]="mainFormGroup.controls['forDisabled']"
+        [label]="'Disabled text-input'"
+        [helpText]="'You should be able to focus on this input but not insert any values'"
+        [disabled]="true"
+      />
     </form>
   `,
 })
@@ -95,6 +101,7 @@ class TextInputWithFormControlExampleComponent {
       null,
       FudisValidators.pattern(/^[A-Z \d\W]+$/, 'YOU USED LOW CAPS! SHAME ON YOU!'),
     ),
+    forDisabled: new FormControl('', [FudisValidators.maxLength(100, 'Too long input')]),
   });
 }
 
@@ -142,6 +149,7 @@ TextInput.args = {
   label: 'Text-input label example',
   control: new FormControl('', FudisValidators.required('This is required field.')),
   helpText: 'Example help text',
+  disabled: true,
 };
 
 export const Examples: StoryFn = () => ({

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.stories.ts
@@ -149,7 +149,6 @@ TextInput.args = {
   label: 'Text-input label example',
   control: new FormControl('', FudisValidators.required('This is required field.')),
   helpText: 'Example help text',
-  disabled: true,
 };
 
 export const Examples: StoryFn = () => ({

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/fieldset-base/fieldset-base.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/fieldset-base/fieldset-base.directive.spec.ts
@@ -1,0 +1,131 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FudisIdService } from '../../../services/id/id.service';
+import { FudisTranslationService } from '../../../services/translation/translation.service';
+import { FieldSetBaseDirective } from './fieldset-base.directive';
+import { Component } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FudisCheckboxOption } from '../../../types/forms';
+import { CheckboxComponent } from '../../../components/form/checkbox-group/checkbox/checkbox.component';
+import { CheckboxGroupComponent } from '../../../components/form/checkbox-group/checkbox-group.component';
+import { FieldSetComponent } from '../../../components/form/fieldset/fieldset.component';
+import { GridDirective } from '../../grid/grid/grid.directive';
+import { FudisBreakpointService } from '../../../services/breakpoint/breakpoint.service';
+import { FudisGridService } from '../../../services/grid/grid.service';
+import { GuidanceComponent } from '../../../components/form/guidance/guidance.component';
+import { ContentDirective } from '../../content-projection/content/content.directive';
+import { getElement } from '../../../utilities/tests/utilities';
+
+@Component({
+  selector: 'fudis-mock-checkbox-group-component',
+  template: ` <fudis-checkbox-group
+    [title]="title"
+    [helpText]="helpText"
+    [required]="true"
+    [formGroup]="_checkboxFormGroup"
+  >
+    <fudis-checkbox
+      *ngFor="let option of _checkboxOptions"
+      [controlName]="option.controlName"
+      [label]="option.label"
+    />
+  </fudis-checkbox-group>`,
+})
+class MockCheckboxGroupComponent {
+  constructor(
+    private _idService: FudisIdService,
+    private _translationService: FudisTranslationService,
+  ) {}
+
+  title = 'This is checkbox group';
+  helpText = 'Here are some advices';
+
+  private _checkboxOptions: FudisCheckboxOption[] = [
+    { controlName: 'blueberry', label: 'blueberry' },
+    { controlName: 'cloudberry', label: 'cloudberry' },
+  ];
+
+  private _checkboxFormGroup = new FormGroup({
+    blueberry: new FormControl<FudisCheckboxOption | null>(null),
+    cloudberry: new FormControl<FudisCheckboxOption | null>(null),
+  });
+}
+
+describe('FieldSetBaseDirective', () => {
+  let idService: FudisIdService;
+  let translationService: FudisTranslationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ContentDirective,
+        CheckboxComponent,
+        CheckboxGroupComponent,
+        FieldSetBaseDirective,
+        FieldSetComponent,
+        GuidanceComponent,
+        GridDirective,
+        MockCheckboxGroupComponent,
+      ],
+      providers: [
+        FudisIdService,
+        FudisTranslationService,
+        FudisBreakpointService,
+        FudisGridService,
+      ],
+      imports: [ReactiveFormsModule],
+    });
+
+    idService = TestBed.inject(FudisIdService);
+    translationService = TestBed.inject(FudisTranslationService);
+  });
+
+  it('should create an instance', () => {
+    TestBed.runInInjectionContext(() => {
+      const directive: FieldSetBaseDirective = new FieldSetBaseDirective(
+        idService,
+        translationService,
+      );
+
+      expect(directive).toBeTruthy();
+    });
+  });
+
+  describe('Input values', () => {
+    let fixtureMock: ComponentFixture<MockCheckboxGroupComponent>;
+
+    beforeEach(() => {
+      fixtureMock = TestBed.createComponent(MockCheckboxGroupComponent);
+      fixtureMock.detectChanges();
+    });
+
+    it('should have title', () => {
+      const titleElement = getElement(fixtureMock, '.fudis-fieldset__legend__title__text');
+
+      expect(titleElement.textContent).toEqual('This is checkbox group (Required)');
+    });
+
+    it('should have title size with respective CSS class', () => {
+      const titleSizeClass = getElement(fixtureMock, '.fudis-fieldset__legend__title__main');
+
+      expect(titleSizeClass.className).toContain('fudis-fieldset__legend__title__main__sm');
+    });
+
+    it('should have id constructed through Fudis id service', () => {
+      const fieldSetElement = getElement(fixtureMock, 'fieldset');
+
+      expect(fieldSetElement.id).toEqual('fudis-checkbox-group-1');
+    });
+
+    it('should have guidance with correct id', () => {
+      const guidanceElement = getElement(fixtureMock, 'fudis-guidance div div');
+
+      expect(guidanceElement.id).toEqual('fudis-checkbox-group-1_guidance');
+    });
+
+    it('should have correct helptext in the guidance', () => {
+      const helpText = getElement(fixtureMock, '.fudis-guidance__help-text');
+
+      expect(helpText.textContent).toContain('Here are some advices');
+    });
+  });
+});

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/fieldset-base/fieldset-base.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/fieldset-base/fieldset-base.directive.spec.ts
@@ -117,7 +117,7 @@ describe('FieldSetBaseDirective', () => {
     });
 
     it('should have guidance with correct id', () => {
-      const guidanceElement = getElement(fixtureMock, 'fudis-guidance div div');
+      const guidanceElement = getElement(fixtureMock, 'fudis-guidance .fudis-guidance div');
 
       expect(guidanceElement.id).toEqual('fudis-checkbox-group-1_guidance');
     });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/fieldset-base/fieldset-base.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/fieldset-base/fieldset-base.directive.spec.ts
@@ -31,11 +31,6 @@ import { getElement } from '../../../utilities/tests/utilities';
   </fudis-checkbox-group>`,
 })
 class MockCheckboxGroupComponent {
-  constructor(
-    private _idService: FudisIdService,
-    private _translationService: FudisTranslationService,
-  ) {}
-
   title = 'This is checkbox group';
   helpText = 'Here are some advices';
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/fieldset-base/fieldset-base.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/fieldset-base/fieldset-base.directive.spec.ts
@@ -122,7 +122,7 @@ describe('FieldSetBaseDirective', () => {
       expect(guidanceElement.id).toEqual('fudis-checkbox-group-1_guidance');
     });
 
-    it('should have correct helptext in the guidance', () => {
+    it('should have correct helpText in guidance', () => {
       const helpText = getElement(fixtureMock, '.fudis-guidance__help-text');
 
       expect(helpText.textContent).toContain('Here are some advices');

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/input-base/input-base.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/input-base/input-base.directive.spec.ts
@@ -146,7 +146,7 @@ describe('InputBaseDirective', () => {
     });
 
     it('should have guidance with correct id', () => {
-      const guidanceElement = getElement(fixtureMock, 'fudis-guidance div div');
+      const guidanceElement = getElement(fixtureMock, 'fudis-guidance .fudis-guidance div');
 
       expect(guidanceElement).toBeTruthy();
       expect(guidanceElement.id).toEqual('fudis-text-input-1_guidance');

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/input-base/input-base.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/input-base/input-base.directive.spec.ts
@@ -155,7 +155,10 @@ describe('InputBaseDirective', () => {
     });
 
     it('should have correct aria-label', () => {
-      const textInputAriaLabel = getElement(fixtureMock, 'fudis-text-input .fudis-text-input__input');
+      const textInputAriaLabel = getElement(
+        fixtureMock,
+        'fudis-text-input .fudis-text-input__input',
+      );
 
       expect(textInputAriaLabel.getAttribute('aria-label')).toEqual('More info in this aria-label');
     });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/input-base/input-base.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/input-base/input-base.directive.spec.ts
@@ -13,7 +13,6 @@ import { LabelComponent } from '../../../components/form/label/label.component';
 @Component({
   selector: 'fudis-mock-text-input-component',
   template: ` <fudis-text-input
-    #inputRef
     [label]="label"
     [helpText]="helpText"
     [required]="required"
@@ -25,11 +24,6 @@ import { LabelComponent } from '../../../components/form/label/label.component';
   />`,
 })
 class MockTextInputComponent {
-  constructor(
-    private _idService: FudisIdService,
-    private _translationService: FudisTranslationService,
-  ) {}
-
   label = 'This is text-input label';
   helpText = 'Here are some advices';
   required = false;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/input-base/input-base.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/input-base/input-base.directive.spec.ts
@@ -1,0 +1,180 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FudisIdService } from '../../../services/id/id.service';
+import { FudisTranslationService } from '../../../services/translation/translation.service';
+import { InputBaseDirective } from './input-base.directive';
+import { Component } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { GuidanceComponent } from '../../../components/form/guidance/guidance.component';
+import { getElement } from '../../../utilities/tests/utilities';
+import { TextInputComponent } from '../../../components/form/text-input/text-input.component';
+import { ValidatorErrorMessageComponent } from '../../../components/form/error-message/validator-error-message/validator-error-message.component';
+import { LabelComponent } from '../../../components/form/label/label.component';
+
+@Component({
+  selector: 'fudis-mock-text-input-component',
+  template: ` <fudis-text-input
+    #inputRef
+    [label]="label"
+    [helpText]="helpText"
+    [required]="required"
+    [disabled]="disabled"
+    [invalidState]="invalidState"
+    [control]="textInputControl"
+    [disableGuidance]="disableGuidance"
+    [initialFocus]="initialFocus"
+  />`,
+})
+class MockTextInputComponent {
+  constructor(
+    private _idService: FudisIdService,
+    private _translationService: FudisTranslationService,
+  ) {}
+
+  label = 'This is text-input label';
+  helpText = 'Here are some advices';
+  required = false;
+  disabled = false;
+  invalidState = false;
+  disableGuidance = false;
+  initialFocus = false;
+
+  textInputControl = new FormControl<string | null | number>(null);
+}
+
+describe('InputBaseDirective', () => {
+  let idService: FudisIdService;
+  let translationService: FudisTranslationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        GuidanceComponent,
+        LabelComponent,
+        MockTextInputComponent,
+        TextInputComponent,
+        ValidatorErrorMessageComponent,
+      ],
+      providers: [FudisIdService, FudisTranslationService],
+      imports: [ReactiveFormsModule],
+    });
+
+    idService = TestBed.inject(FudisIdService);
+    translationService = TestBed.inject(FudisTranslationService);
+  });
+
+  describe('Directive', () => {
+    it('should create an instance', () => {
+      TestBed.runInInjectionContext(() => {
+        const directive: InputBaseDirective = new InputBaseDirective(translationService, idService);
+
+        expect(directive).toBeTruthy();
+      });
+    });
+
+    it('should emit blur event', () => {
+      TestBed.runInInjectionContext(() => {
+        const directive: InputBaseDirective = new InputBaseDirective(translationService, idService);
+        const event = new FocusEvent('blur');
+
+        jest.spyOn(directive.handleBlur, 'emit');
+        directive.onBlur(event);
+
+        expect(directive.handleBlur.emit).toHaveBeenCalled();
+      });
+    });
+
+    it('should call focusToInput', () => {
+      TestBed.runInInjectionContext(() => {
+        const directive: InputBaseDirective = new InputBaseDirective(translationService, idService);
+
+        jest.spyOn(directive, 'focusToInput').mockImplementation(() => {});
+        directive.focusToInput();
+
+        expect(directive.focusToInput).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Input values', () => {
+    let componentMock: MockTextInputComponent;
+    let fixtureMock: ComponentFixture<MockTextInputComponent>;
+
+    beforeEach(() => {
+      fixtureMock = TestBed.createComponent(MockTextInputComponent);
+      componentMock = fixtureMock.componentInstance;
+      fixtureMock.detectChanges();
+    });
+
+    it('should have label with required indicator', () => {
+      componentMock.required = true;
+      fixtureMock.detectChanges();
+
+      const labelElement = getElement(fixtureMock, '.fudis-label__content__text');
+      const requiredIndicator = getElement(fixtureMock, '.fudis-label__content__required');
+
+      expect(labelElement.textContent).toEqual('This is text-input label');
+      expect(requiredIndicator.textContent).toEqual('(Required)');
+    });
+
+    it('should have id constructed through Fudis id service', () => {
+      const labelElement = getElement(fixtureMock, '.fudis-label');
+
+      expect(labelElement.id).toEqual('fudis-text-input-1-label');
+    });
+
+    it('should be disabled with respective CSS class and aria-attribute', () => {
+      componentMock.disabled = true;
+      fixtureMock.detectChanges();
+
+      const disabledInput = getElement(fixtureMock, 'input');
+      const inputAriaAttribute = !!disabledInput.getAttribute('aria-disabled');
+
+      expect(disabledInput.className).toContain('fudis-form-input--disabled');
+      expect(inputAriaAttribute).toEqual(true);
+    });
+
+    it('should be invalid with respective CSS class and aria-attribute', () => {
+      componentMock.invalidState = true;
+      componentMock.textInputControl.markAllAsTouched();
+      fixtureMock.detectChanges();
+
+      const invalidInput = getElement(fixtureMock, 'input');
+      const inputAriaAttribute = !!invalidInput.getAttribute('aria-invalid');
+
+      expect(invalidInput.className).toContain('fudis-form-input--invalid');
+      expect(inputAriaAttribute).toEqual(true);
+    });
+
+    it('should have guidance with correct id', () => {
+      const guidanceElement = getElement(fixtureMock, 'fudis-guidance div div');
+
+      expect(guidanceElement).toBeTruthy();
+      expect(guidanceElement.id).toEqual('fudis-text-input-1_guidance');
+    });
+
+    it('should have correct helpText in guidance', () => {
+      const helpText = getElement(fixtureMock, '.fudis-guidance__help-text');
+
+      expect(helpText.textContent).toContain('Here are some advices');
+    });
+
+    it('should not have guidance present if disableGuidance is set', () => {
+      componentMock.disableGuidance = true;
+      fixtureMock.detectChanges();
+
+      const guidanceElement = getElement(fixtureMock, 'fudis-guidance');
+
+      expect(guidanceElement).toBeFalsy();
+    });
+
+    it('should have ng-reflect if initialFocus is set', () => {
+      componentMock.initialFocus = true;
+      fixtureMock.detectChanges();
+
+      const textInputElement = getElement(fixtureMock, 'fudis-text-input');
+      const textInputAttribute = !!textInputElement.getAttribute('ng-reflect-initial-focus');
+
+      expect(textInputAttribute).toEqual(true);
+    });
+  });
+});

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/input-base/input-base.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/input-base/input-base.directive.spec.ts
@@ -21,11 +21,13 @@ import { LabelComponent } from '../../../components/form/label/label.component';
     [control]="textInputControl"
     [disableGuidance]="disableGuidance"
     [initialFocus]="initialFocus"
+    [ariaLabel]="ariaLabel"
   />`,
 })
 class MockTextInputComponent {
   label = 'This is text-input label';
   helpText = 'Here are some advices';
+  ariaLabel = 'More info in this aria-label';
   required = false;
   disabled = false;
   invalidState = false;
@@ -150,6 +152,12 @@ describe('InputBaseDirective', () => {
       const helpText = getElement(fixtureMock, '.fudis-guidance__help-text');
 
       expect(helpText.textContent).toContain('Here are some advices');
+    });
+
+    it('should have correct aria-label', () => {
+      const textInputAriaLabel = getElement(fixtureMock, 'fudis-text-input .fudis-text-input__input');
+
+      expect(textInputAriaLabel.getAttribute('aria-label')).toEqual('More info in this aria-label');
     });
 
     it('should not have guidance present if disableGuidance is set', () => {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/foundations/utilities/classes.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/foundations/utilities/classes.scss
@@ -15,8 +15,32 @@
   @include mixins.horizontal-rule;
 }
 
+// Invalid and disabled state styles for input elemenets
 /* stylelint-disable-next-line selector-no-qualifying-type */
 input.fudis-form-input {
+  /* stylelint-disable-next-line selector-no-qualifying-type */
+  &--invalid[aria-invalid="true"] {
+    @include border.border("1px", "solid", "red");
+  }
+
+  &--disabled {
+    @include border.border("1px", "dashed", "gray-middle");
+    @include colors.bg-color("gray-extra-light");
+
+    cursor: default;
+  }
+
+  // TODO: Unifiy below and above --disabled styles for inputs to work universally
+  // This is done for text-input, otherwise its own styles overwrite border styles
+  /* stylelint-disable-next-line selector-no-qualifying-type */
+  &--disabled[aria-disabled="true"] {
+    @include border.border("1px", "dashed", "gray-middle");
+  }
+}
+
+// Invalid and disabled state styles for text-area elements
+/* stylelint-disable-next-line selector-no-qualifying-type */
+textarea.fudis-form-input {
   /* stylelint-disable-next-line selector-no-qualifying-type */
   &--invalid[aria-invalid="true"] {
     @include border.border("1px", "solid", "red");

--- a/ngx-fudis/projects/ngx-fudis/src/lib/foundations/utilities/classes.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/foundations/utilities/classes.scss
@@ -30,7 +30,7 @@ input.fudis-form-input {
     cursor: default;
   }
 
-  // TODO: Unifiy below and above --disabled styles for inputs to work universally
+  // TODO: Unify below and above --disabled styles for inputs to work universally
   // This is done for text-input, otherwise its own styles overwrite border styles
   /* stylelint-disable-next-line selector-no-qualifying-type */
   &--disabled[aria-disabled="true"] {


### PR DESCRIPTION
https://jira.funidata.fi/browse/DS-195

_Extra:_
Noticed that both `text-input` and `text-area` components were missing disabled state styles. `Text-area` was also missing invalid state styles. This was noticed since I wanted to test disabled state CSS class passing in `InputBaseDirective` unit tests.