### PR TITLE
Fix problems with Prettier's parsing of tsconfig.json files

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,0 @@
-{ "printWidth": 100 }

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,8 @@
+printWidth: 100
+overrides:
+  # Explicitly use JSON parser for TS config files to avoid confusing problems with formatting.
+  # See https://github.com/prettier/prettier/issues/15942
+  - files:
+      - tsconfig.json
+    options:
+      parser: json

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -5,9 +5,9 @@
     "target": "es5",
     "lib": ["es5", "dom"],
     "types": ["cypress", "node"],
-    "sourceMap": false,
+    "sourceMap": false
   },
   "include": ["**/*/*.ts"],
   "exclude": [],
-  "files": ["../cypress-image-diff.config.ts", "../cypress.config.ts"],
+  "files": ["../cypress-image-diff.config.ts", "../cypress.config.ts"]
 }

--- a/ngx-fudis/.storybook/tsconfig.json
+++ b/ngx-fudis/.storybook/tsconfig.json
@@ -2,14 +2,14 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "types": ["node"],
-    "allowSyntheticDefaultImports": true,
+    "allowSyntheticDefaultImports": true
   },
   "exclude": [
     "../src/test.ts",
     "../src/**/*.spec.ts",
     "../projects/**/*.spec.ts",
-    "../projects/dev/**/*",
+    "../projects/dev/**/*"
   ],
   "include": ["../src/**/*", "../projects/**/*", "../stories/**/*"],
-  "files": ["./typings.d.ts"],
+  "files": ["./typings.d.ts"]
 }

--- a/ngx-fudis/package-lock.json
+++ b/ngx-fudis/package-lock.json
@@ -56,7 +56,7 @@
         "jest-preset-angular": "^14.0.0",
         "ng-mocks": "14.12.1",
         "ng-packagr": "16.2.3",
-        "prettier": "3.2.4",
+        "prettier": "^3.2.5",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "remark-gfm": "4.0.0",
@@ -26095,9 +26095,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
-      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/ngx-fudis/package.json
+++ b/ngx-fudis/package.json
@@ -65,7 +65,7 @@
     "jest-preset-angular": "^14.0.0",
     "ng-mocks": "14.12.1",
     "ng-packagr": "16.2.3",
-    "prettier": "3.2.4",
+    "prettier": "^3.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "remark-gfm": "4.0.0",

--- a/ngx-fudis/tsconfig.json
+++ b/ngx-fudis/tsconfig.json
@@ -12,7 +12,7 @@
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
     "paths": {
-      "ngx-fudis": ["dist/ngx-fudis/ngx-fudis", "dist/ngx-fudis"],
+      "ngx-fudis": ["dist/ngx-fudis/ngx-fudis", "dist/ngx-fudis"]
     },
     "declaration": false,
     "downlevelIteration": true,
@@ -24,14 +24,14 @@
     "lib": ["ES2021", "dom"],
     "strictPropertyInitialization": false,
     "useDefineForClassFields": false,
-    "esModuleInterop": true,
+    "esModuleInterop": true
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
-    "strictTemplates": true,
+    "strictTemplates": true
   },
   "include": ["projects", "types", "jest.config.ts"],
-  "exclude": ["./cypress"],
+  "exclude": ["./cypress"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "CC-BY-NC-SA-4.0",
       "devDependencies": {
         "husky": "^8.0.3",
-        "prettier": "^3.2.4"
+        "prettier": "^3.2.5"
       }
     },
     "node_modules/husky": {
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
-      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -53,9 +53,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
-      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "homepage": "https://funidata.github.io/fudis/main/",
   "devDependencies": {
     "husky": "^8.0.3",
-    "prettier": "^3.2.4"
+    "prettier": "^3.2.5"
   }
 }


### PR DESCRIPTION
Explicitly use JSON parser for formatting `tsconfig.json` files to avoid the problems described here: https://github.com/prettier/prettier/issues/15942