### PR TITLE
[Form, ErrorSummary]: Add onClick link type to support non Angular Router apps

### DIFF
--- a/ngx-fudis/projects/dev/src/app/app.component.html
+++ b/ngx-fudis/projects/dev/src/app/app.component.html
@@ -148,7 +148,7 @@
   <fudis-dialog [size]="'sm'">
     <fudis-dialog-content>
       <fudis-form
-        [errorSummaryLinkType]="'href'"
+        [errorSummaryLinkType]="'onClick'"
         [errorSummaryVisible]="errorSummaryVisible"
         [title]="'Dialog with fudis-form'"
         [errorSummaryHelpText]="'You did not fill all the required information'"

--- a/ngx-fudis/projects/dev/src/app/components/formExamples.component.html
+++ b/ngx-fudis/projects/dev/src/app/components/formExamples.component.html
@@ -2,8 +2,6 @@
   <fudis-expandable [title]="'Form with some transloco'" [closed]="false">
     <ng-template fudisActions type="expandable">
       <fudis-button
-        fudisFormSubmit
-        [formValid]="testFormGroup.valid"
         [label]="'Submit!'"
         (handleClick)="clickSubmit()"
       ></fudis-button>

--- a/ngx-fudis/projects/dev/src/app/components/formExamples.component.html
+++ b/ngx-fudis/projects/dev/src/app/components/formExamples.component.html
@@ -1,10 +1,7 @@
 <ng-container *transloco="let t">
   <fudis-expandable [title]="'Form with some transloco'" [closed]="false">
     <ng-template fudisActions type="expandable">
-      <fudis-button
-        [label]="'Submit!'"
-        (handleClick)="clickSubmit()"
-      ></fudis-button>
+      <fudis-button [label]="'Submit!'" (handleClick)="clickSubmit()"></fudis-button>
       <fudis-button
         [label]="'Custom error status: ' + customError"
         (handleClick)="toggleCustomError()"

--- a/ngx-fudis/projects/dev/src/app/components/formExamples.component.html
+++ b/ngx-fudis/projects/dev/src/app/components/formExamples.component.html
@@ -14,7 +14,7 @@
     </ng-template>
     <ng-template fudisContent type="expandable">
       <fudis-form
-        [errorSummaryLinkType]="'href'"
+        [errorSummaryLinkType]="'onClick'"
         [errorSummaryVisible]="errorSummaryVisible"
         [title]="'Form title here hello'"
         [errorSummaryHelpText]="'There were some errors'"

--- a/ngx-fudis/projects/dev/src/app/components/formExamples.component.ts
+++ b/ngx-fudis/projects/dev/src/app/components/formExamples.component.ts
@@ -168,7 +168,14 @@ export class AppFormExampleComponent implements OnInit {
   }
 
   clickSubmit(): void {
-    if (this.testFormGroup.valid) {
+    this.testFormGroup.markAllAsTouched();
+
+    if (this.testFormGroup.invalid) {
+      this.errorSummaryVisible = true;
+      this.showSuccessBodyText = false;
+      this._errorSummaryService.reloadAllErrors();
+    } else {
+      this.errorSummaryVisible = false;
       this.showSuccessBodyText = true;
     }
   }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.stories.ts
@@ -40,7 +40,7 @@ type TestForm = {
             [errorSummaryVisible]="errorSummaryVisible"
             [title]="'Dialog with fudis-form'"
             [titleLevel]="2"
-            [errorSummaryLinkType]="'href'"
+            [errorSummaryLinkType]="'onClick'"
             [errorSummaryHelpText]="'You need to fill up the information.'"
           >
             <ng-template fudisContent [type]="'form'">

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.html
@@ -29,6 +29,14 @@
                   [title]="error.message"
                 ></fudis-link>
               </ng-container>
+              <ng-container *ngIf="linkType === 'onClick'">
+                <fudis-link
+                  (handleClick)="handleErrorClick($event, error.id)"
+                  [size]="'md'"
+                  [href]="'#'"
+                  [title]="error.message"
+                ></fudis-link>
+              </ng-container>
             </li>
           </ul>
         </div>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.ts
@@ -98,6 +98,22 @@ export class ErrorSummaryComponent implements AfterViewInit {
   private _numberOfFocusTries: number = 0;
 
   /**
+   * To enable clicking Error Summary links and then moving focus to corresponding form field. This was needed, as not all Fudis applications use Angular Router, so alternative approach was needed.
+   *
+   * @param event Original click event
+   * @param clickedId Id of clicked link in Error Summary
+   */
+  protected handleErrorClick(event: Event, clickedId: string): void {
+    event.preventDefault();
+
+    const linkToFocus = this.parentComponent.querySelector(`#${clickedId}`) as HTMLInputElement;
+
+    if (linkToFocus) {
+      linkToFocus.focus();
+    }
+  }
+
+  /**
    * Sort errors the same order they appear in the DOM
    */
   private _sortErrorOrder(a: FudisFormErrorSummaryList, b: FudisFormErrorSummaryList): 0 | -1 | 1 {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.stories.ts
@@ -23,7 +23,7 @@ import { excludeAllRegex } from '../../../utilities/storybook';
     [titleLevel]="1"
     [title]="'Example Form with Error Summary'"
     [id]="id"
-    [errorSummaryLinkType]="'href'"
+    [errorSummaryLinkType]="'onClick'"
     [errorSummaryHelpText]="
       'Toggle live remove button to see errors disappear when input value is corrected'
     "

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.stories.ts
@@ -37,7 +37,7 @@ import { FudisErrorSummaryService } from '../../../services/form/error-summary/e
       <fudis-form
         [titleLevel]="2"
         [title]="'Form with Text Input'"
-        [errorSummaryLinkType]="'href'"
+        [errorSummaryLinkType]="'onClick'"
         [errorSummaryVisible]="errorSummaryVisible"
         [errorSummaryHelpText]="errorSummaryHelpText"
       >
@@ -62,7 +62,7 @@ import { FudisErrorSummaryService } from '../../../services/form/error-summary/e
       <fudis-form
         [titleLevel]="2"
         [title]="'Form with Text Area'"
-        [errorSummaryLinkType]="'href'"
+        [errorSummaryLinkType]="'onClick'"
         [errorSummaryVisible]="errorSummaryVisible"
         [errorSummaryHelpText]="errorSummaryHelpText"
       >
@@ -87,7 +87,7 @@ import { FudisErrorSummaryService } from '../../../services/form/error-summary/e
       <fudis-form
         [titleLevel]="2"
         [title]="'Form with Checkbox Group'"
-        [errorSummaryLinkType]="'href'"
+        [errorSummaryLinkType]="'onClick'"
         [errorSummaryVisible]="errorSummaryVisible"
         [errorSummaryHelpText]="errorSummaryHelpText"
       >
@@ -118,7 +118,7 @@ import { FudisErrorSummaryService } from '../../../services/form/error-summary/e
       <fudis-form
         [titleLevel]="2"
         [title]="'Form with Select and Multiselect'"
-        [errorSummaryLinkType]="'href'"
+        [errorSummaryLinkType]="'onClick'"
         [errorSummaryVisible]="errorSummaryVisible"
         [errorSummaryHelpText]="errorSummaryHelpText"
       >

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.stories.ts
@@ -535,7 +535,7 @@ export default {
       },
     },
     errorSummaryLinkType: {
-      options: ['href', 'router'],
+      options: ['href', 'router', 'onClick'],
       control: {
         type: 'select',
       },
@@ -569,7 +569,7 @@ Example.args = {
   badgeText: 'Example',
   errorSummaryHelpText:
     'There are errors in this form. Please address these before trying to submit again.',
-  errorSummaryLinkType: 'href',
+  errorSummaryLinkType: 'onClick',
   errorSummaryVisible: false,
 };
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/types/forms.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/types/forms.ts
@@ -138,6 +138,6 @@ export const FUDIS_DATE_FORMATS: MatDateFormats = {
   },
 };
 
-export type FudisFormErrorSummaryLink = 'router' | 'href';
+export type FudisFormErrorSummaryLink = 'router' | 'href' | 'onClick';
 
 export type FudisFormErrorSummaryUpdateStrategy = 'reloadOnly' | 'all' | 'onRemove';


### PR DESCRIPTION
Jira ticket: https://funidata.atlassian.net/browse/DS-274
To enable focusing from Error Summary to corresponding form fields, if Fudis application does not use Angular Router.