### PR TITLE
[DropdownItemBase]: Fix for unwanted dropdown close when multiselect is a child component of fieldset

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-base/select-base.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-base/select-base.directive.ts
@@ -188,6 +188,8 @@ export class SelectBaseDirective extends InputBaseDirective implements OnDestroy
    * @param preventDropdownReopen: For cases, when closing command comes from outside eg. clicking an option in the dropdownlist. There's no need to reopen the dropdown when focusing back to the input, which usually triggers opening the dropdown.
    */
   public closeDropdown(focusToInput: boolean = true, preventDropdownReopen: boolean = false): void {
+    console.log('kukkuu');
+
     this._dropdownOpen = false;
 
     this._preventDropdownReopen = preventDropdownReopen;
@@ -239,18 +241,13 @@ export class SelectBaseDirective extends InputBaseDirective implements OnDestroy
    * To handle input field blur events
    * @param event FocusEvent
    */
-  protected _inputBlur(event: FocusEvent): void {
+  protected _inputBlur(): void {
     // Time out used for user mouse click cases
-
-    if (!event.relatedTarget) {
-      setTimeout(() => {
-        if (!document.activeElement?.classList?.contains(this.focusSelector)) {
-          this.closeDropdown(false);
-        }
-      }, 150);
-    } else if (!(event.relatedTarget as HTMLElement)?.classList?.contains(this.focusSelector)) {
-      this.closeDropdown(false);
-    }
+    setTimeout(() => {
+      if (!document.activeElement?.classList?.contains(this.focusSelector)) {
+        this.closeDropdown(false);
+      }
+    }, 150);
     this._inputFocused = false;
     this.control.markAsTouched();
   }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-base/select-base.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-base/select-base.directive.ts
@@ -188,8 +188,6 @@ export class SelectBaseDirective extends InputBaseDirective implements OnDestroy
    * @param preventDropdownReopen: For cases, when closing command comes from outside eg. clicking an option in the dropdownlist. There's no need to reopen the dropdown when focusing back to the input, which usually triggers opening the dropdown.
    */
   public closeDropdown(focusToInput: boolean = true, preventDropdownReopen: boolean = false): void {
-    console.log('kukkuu');
-
     this._dropdownOpen = false;
 
     this._preventDropdownReopen = preventDropdownReopen;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect.component.html
@@ -20,7 +20,7 @@
       aria-haspopup="listbox"
       (click)="_clickInput($event)"
       (focus)="_inputFocus()"
-      (blur)="_inputBlur($event)"
+      (blur)="_inputBlur()"
       (keydown)="_dropdownKeypress($event, focusSelector)"
       [attr.aria-autocomplete]="'none'"
       [attr.aria-expanded]="_dropdownOpen"
@@ -64,7 +64,7 @@
       (triggerDropdownClose)="closeDropdown()"
       (triggerDropdownToggle)="_toggleDropdown()"
       (triggerFocus)="_inputFocus()"
-      (triggerBlur)="_inputBlur($event)"
+      (triggerBlur)="_inputBlur()"
     />
   </div>
   <fudis-select-dropdown

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/select/select.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/select/select.component.html
@@ -21,7 +21,7 @@
       [attr.aria-activedescendant]="control.value?.['htmlId'] ? control.value?.['htmlId'] : null"
       (click)="_clickInput($event)"
       (focus)="_inputFocus()"
-      (blur)="_inputBlur($event)"
+      (blur)="_inputBlur()"
       (keydown)="_dropdownKeypress($event, this.focusSelector)"
       [attr.aria-autocomplete]="'none'"
       [attr.aria-expanded]="_dropdownOpen"
@@ -66,7 +66,7 @@
       (triggerDropdownClose)="closeDropdown()"
       (triggerDropdownToggle)="_toggleDropdown()"
       (triggerFocus)="_inputFocus()"
-      (triggerBlur)="_inputBlur($event)"
+      (triggerBlur)="_inputBlur()"
     />
   </div>
   <fudis-select-dropdown

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/dropdown-item-base/dropdown-item-base.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/dropdown-item-base/dropdown-item-base.directive.ts
@@ -72,6 +72,8 @@ export class DropdownItemBaseDirective {
   }
 
   /**
+   * TODO: this spaghetti should be rethought
+   *
    * Function which tries to check if UI focus has moved away from the list of dropdown items
    */
   // eslint-disable-next-line class-methods-use-this
@@ -116,14 +118,20 @@ export class DropdownItemBaseDirective {
         '.fudis-select__input-wrapper__icon-button button',
       );
 
-      if (
-        !(event.relatedTarget as HTMLElement)?.classList?.contains(selector) &&
-        (event.relatedTarget as HTMLElement) !== selectInput &&
-        (event.relatedTarget as HTMLElement) !== menuButton &&
-        (event.relatedTarget as HTMLElement) !== autocompleteChevronButton
-      ) {
-        return true;
-      }
+      setTimeout(() => {
+        const optionAsActiveElement = document.activeElement?.classList.contains(selector);
+        if (
+          !optionAsActiveElement &&
+          !(event.relatedTarget as HTMLElement)?.classList?.contains(selector) &&
+          (event.relatedTarget as HTMLElement) !== selectInput &&
+          (event.relatedTarget as HTMLElement) !== menuButton &&
+          (event.relatedTarget as HTMLElement) !== autocompleteChevronButton
+        ) {
+          return true;
+        } else {
+          return false;
+        }
+      }, 150);
     }
 
     return false;


### PR DESCRIPTION
Noticed a bug, when Multiselect was used as child of Fieldset and added some duck tape fix to it. The function _focusedOutFromComponent is now quite a spaghetti and should be rethought before releasing Select family for >1.0