### PR TITLE
[CheckboxGroup]: Remove required props

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox-group/checkbox-group.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox-group/checkbox-group.component.ts
@@ -34,12 +34,12 @@ export class CheckboxGroupComponent extends FieldSetBaseDirective implements OnI
   /**
    * FormGroup or FormArray for Checkbox group.
    */
-  @Input({ required: true }) formGroup: FormGroup<FudisCheckboxGroupFormGroup<object>>;
+  @Input() formGroup: FormGroup<FudisCheckboxGroupFormGroup<object>>;
 
   /**
    * FormArray for Checkbox group.
    */
-  @Input({ required: true }) formArray: FormArray<FormControl<boolean | null | undefined>>;
+  @Input() formArray: FormArray<FormControl<boolean | null | undefined>>;
 
   /**
    * Width size of the group.

--- a/ngx-fudis/projects/ngx-fudis/src/lib/types/forms.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/types/forms.ts
@@ -11,9 +11,9 @@ export interface FudisCheckboxOption {
   id?: string;
   /** Name for the group of checkboxes */
   groupName?: string;
-  /** If using FormGroup, name of of the option */
+  /** If using FormGroup, name of the option */
   controlName?: string;
-  /** If using FormArray, index of of the option */
+  /** If using FormArray, index of the option */
   controlIndex?: number;
   /** Visible label that is shown in the UI */
   label: string;


### PR DESCRIPTION
In previous PR both formArray and formGroup were marked as required inputs, which was unintentional.