### PR TITLE
[Dialog & Form]: Form header compatibility within dialog

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.html
@@ -12,20 +12,28 @@
 >
 </fudis-button>
 <div class="fudis-dialog fudis-dialog__size__{{ size }}" [attr.id]="_id">
-  <fudis-heading
-    *ngIf="formTitle && formTitleLevel"
-    fudisDialogTitle
-    [level]="formTitleLevel"
-    [marginBottom]="'xs'"
-    class="fudis-dialog__form__title"
-    >{{ formTitle }}
-    <ng-container *ngIf="formBadge && formBadgeText">
-      <fudis-badge
-        class="fudis-dialog__form__title__badge"
-        [variant]="formBadge"
-        [content]="formBadgeText"
-      />
+  <div
+    *ngIf="dialogFormTitle && dialogFormTitleLevel"
+    class="fudis-dialog__form__header"
+    aria-hidden="true"
+  >
+    <fudis-heading
+      fudisDialogTitle
+      [level]="dialogFormTitleLevel"
+      [marginBottom]="'xs'"
+      class="fudis-dialog__form__header__title"
+      >{{ dialogFormTitle }}
+      <ng-container *ngIf="dialogFormBadge && dialogFormBadgeText">
+        <fudis-badge
+          class="fudis-dialog__form__header__title__badge"
+          [variant]="dialogFormBadge"
+          [content]="dialogFormBadgeText"
+        />
+      </ng-container>
+    </fudis-heading>
+    <ng-container *ngIf="dialogHelpText">
+      <fudis-body-text fudisSpacing [marginBottom]="'xs'">{{ dialogHelpText }}</fudis-body-text>
     </ng-container>
-  </fudis-heading>
+  </div>
   <ng-content></ng-content>
 </div>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.html
@@ -12,27 +12,23 @@
 >
 </fudis-button>
 <div class="fudis-dialog fudis-dialog__size__{{ size }}" [attr.id]="_id">
-  <div
-    *ngIf="dialogFormTitle && dialogFormTitleLevel"
-    class="fudis-dialog__form__header"
-    aria-hidden="true"
-  >
+  <div *ngIf="title && titleLevel" class="fudis-dialog__form__header" aria-hidden="true">
     <fudis-heading
       fudisDialogTitle
-      [level]="dialogFormTitleLevel"
+      [level]="titleLevel"
       [marginBottom]="'xs'"
       class="fudis-dialog__form__header__title"
-      >{{ dialogFormTitle }}
-      <ng-container *ngIf="dialogFormBadge && dialogFormBadgeText">
+      >{{ title }}
+      <ng-container *ngIf="badge && badgeText">
         <fudis-badge
           class="fudis-dialog__form__header__title__badge"
-          [variant]="dialogFormBadge"
-          [content]="dialogFormBadgeText"
+          [variant]="badge"
+          [content]="badgeText"
         />
       </ng-container>
     </fudis-heading>
-    <ng-container *ngIf="dialogHelpText">
-      <fudis-body-text fudisSpacing [marginBottom]="'xs'">{{ dialogHelpText }}</fudis-body-text>
+    <ng-container *ngIf="helpText">
+      <fudis-body-text fudisSpacing [marginBottom]="'xs'">{{ helpText }}</fudis-body-text>
     </ng-container>
   </div>
   <ng-content></ng-content>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.html
@@ -1,16 +1,19 @@
 <!-- <fudis-alert-group [insideDialog]="true" /> -->
+<fudis-button
+  fudisDialogClose
+  class="fudis-dialog__close"
+  [class.fudis-dialog__close__absolute]="closeButtonPositionAbsolute"
+  [attr.id]="_id + '-close'"
+  [label]="_closeLabel"
+  [labelHidden]="true"
+  [size]="'icon-only'"
+  [icon]="'ring-close'"
+  [variant]="'tertiary'"
+>
+</fudis-button>
 <div class="fudis-dialog fudis-dialog__size__{{ size }}" [attr.id]="_id">
-  <fudis-button
-    fudisDialogClose
-    class="fudis-dialog__close"
-    [class.fudis-dialog__close__absolute]="closeButtonPositionAbsolute"
-    [attr.id]="_id + '-close'"
-    [label]="_closeLabel"
-    [labelHidden]="true"
-    [size]="'icon-only'"
-    [icon]="'ring-close'"
-    [variant]="'tertiary'"
-  >
-  </fudis-button>
+  <fudis-heading *ngIf="formTitleLevel" fudisDialogTitle [level]="formTitleLevel">{{
+    formTitle
+  }}</fudis-heading>
   <ng-content></ng-content>
 </div>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.html
@@ -12,8 +12,20 @@
 >
 </fudis-button>
 <div class="fudis-dialog fudis-dialog__size__{{ size }}" [attr.id]="_id">
-  <fudis-heading *ngIf="formTitleLevel" fudisDialogTitle [level]="formTitleLevel">{{
-    formTitle
-  }}</fudis-heading>
+  <fudis-heading
+    *ngIf="formTitle && formTitleLevel"
+    fudisDialogTitle
+    [level]="formTitleLevel"
+    [marginBottom]="'xs'"
+    class="fudis-dialog__form__title"
+    >{{ formTitle }}
+    <ng-container *ngIf="formBadge && formBadgeText">
+      <fudis-badge
+        class="fudis-dialog__form__title__badge"
+        [variant]="formBadge"
+        [content]="formBadgeText"
+      />
+    </ng-container>
+  </fudis-heading>
   <ng-content></ng-content>
 </div>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.scss
@@ -10,11 +10,11 @@
 
   &__close {
     float: right;
+    top: spacing.$spacing-sm;
+    right: spacing.$spacing-sm;
 
     &__absolute {
       position: absolute;
-      top: 0;
-      right: 0;
       float: initial;
     }
   }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.scss
@@ -9,9 +9,9 @@
   max-width: calc(100vw - (2 * spacing.$spacing-sm));
 
   &__close {
-    float: right;
     top: spacing.$spacing-sm;
     right: spacing.$spacing-sm;
+    float: right;
 
     &__absolute {
       position: absolute;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.spec.ts
@@ -77,7 +77,7 @@ describe('DialogComponent', () => {
       component.closeButtonPositionAbsolute = true;
       fixture.detectChanges();
 
-      const closeButtonEl = getElement(fixture, '.fudis-dialog fudis-button');
+      const closeButtonEl = getElement(fixture, '.fudis-dialog__close');
 
       expect(closeButtonEl.className).toEqual('fudis-dialog__close fudis-dialog__close__absolute');
     });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnDestroy, OnInit, effect } from '@angular/core';
 import { FudisDialogService } from '../../services/dialog/dialog.service';
 import { FudisIdService } from '../../services/id/id.service';
 import { FudisTranslationService } from '../../services/translation/translation.service';
-import { FudisDialogSize } from '../../types/miscellaneous';
+import { FudisBadgeVariant, FudisDialogSize } from '../../types/miscellaneous';
 import { FudisHeadingLevel } from '../../types/typography';
 
 @Component({
@@ -45,6 +45,10 @@ export class DialogComponent implements OnInit, OnDestroy {
   public formTitleLevel: FudisHeadingLevel;
 
   public formTitle: string;
+
+  public formBadge: FudisBadgeVariant | null;
+
+  public formBadgeText: string | null;
 
   ngOnInit(): void {
     this._dialogService.setDialogOpenSignal(true);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.ts
@@ -42,13 +42,15 @@ export class DialogComponent implements OnInit, OnDestroy {
    */
   protected _closeLabel: string;
 
-  public formTitleLevel: FudisHeadingLevel;
+  public dialogFormTitleLevel: FudisHeadingLevel;
 
-  public formTitle: string;
+  public dialogFormTitle: string;
 
-  public formBadge: FudisBadgeVariant | null;
+  public dialogFormBadge: FudisBadgeVariant | null;
 
-  public formBadgeText: string | null;
+  public dialogFormBadgeText: string | null;
+
+  public dialogHelpText: string;
 
   ngOnInit(): void {
     this._dialogService.setDialogOpenSignal(true);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.ts
@@ -42,15 +42,15 @@ export class DialogComponent implements OnInit, OnDestroy {
    */
   protected _closeLabel: string;
 
-  public dialogFormTitleLevel: FudisHeadingLevel;
+  public titleLevel: FudisHeadingLevel;
 
-  public dialogFormTitle: string;
+  public title: string;
 
-  public dialogFormBadge: FudisBadgeVariant | null;
+  public badge: FudisBadgeVariant | null;
 
-  public dialogFormBadgeText: string | null;
+  public badgeText: string | null;
 
-  public dialogHelpText: string;
+  public helpText: string;
 
   ngOnInit(): void {
     this._dialogService.setDialogOpenSignal(true);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.ts
@@ -3,6 +3,7 @@ import { FudisDialogService } from '../../services/dialog/dialog.service';
 import { FudisIdService } from '../../services/id/id.service';
 import { FudisTranslationService } from '../../services/translation/translation.service';
 import { FudisDialogSize } from '../../types/miscellaneous';
+import { FudisHeadingLevel } from '../../types/typography';
 
 @Component({
   selector: 'fudis-dialog',
@@ -40,6 +41,10 @@ export class DialogComponent implements OnInit, OnDestroy {
    * Internal translated aria-label for top right close button
    */
   protected _closeLabel: string;
+
+  public formTitleLevel: FudisHeadingLevel;
+
+  public formTitle: string;
 
   ngOnInit(): void {
     this._dialogService.setDialogOpenSignal(true);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.html
@@ -18,22 +18,24 @@
       <ng-container *ngIf="title && titleLevel">
         <div class="fudis-form__header__title">
           <ng-container *ngIf="_dialogParent">
-            <fudis-heading
-              class="fudis-form__header__title__dialog"
-              fudisDialogTitle
-              [marginBottom]="'xs'"
-              [size]="titleSize"
-              [level]="titleLevel"
-            >
-              {{ title }}
-              <ng-container *ngIf="badge && badgeText">
-                <fudis-badge
-                  class="fudis-form__header__title__badge"
-                  [variant]="badge"
-                  [content]="badgeText"
-                />
-              </ng-container>
-            </fudis-heading>
+            <div class="fudis-visually-hidden">
+              <fudis-heading
+                class="fudis-form__header__title__dialog"
+                fudisDialogTitle
+                [marginBottom]="'xs'"
+                [size]="titleSize"
+                [level]="titleLevel"
+              >
+                {{ title }}
+                <ng-container *ngIf="badge && badgeText">
+                  <fudis-badge
+                    class="fudis-form__header__title__badge"
+                    [variant]="badge"
+                    [content]="badgeText"
+                  />
+                </ng-container>
+              </fudis-heading>
+            </div>
           </ng-container>
           <ng-container *ngIf="!_dialogParent">
             <fudis-heading [marginBottom]="'xs'" [size]="titleSize" [level]="titleLevel">
@@ -47,11 +49,15 @@
               </ng-container>
             </fudis-heading>
           </ng-container>
+
           <ng-container *ngIf="helpText">
-            <fudis-body-text fudisSpacing [marginBottom]="'xs'">{{ helpText }}</fudis-body-text>
+            <div [class.fudis-visually-hidden]="_dialogParent">
+              <fudis-body-text fudisSpacing [marginBottom]="'xs'">{{ helpText }}</fudis-body-text>
+            </div>
           </ng-container>
         </div>
       </ng-container>
+
       <ng-container *ngIf="_headerContent">
         <div class="fudis-form__header__main__content">
           <ng-container *ngTemplateOutlet="_headerContent!.templateRef" />
@@ -66,20 +72,20 @@
         />
       </ng-container>
     </div>
+    <ng-container *ngIf="_headerActions?.type === 'form' && !_dialogParent">
+      <div class="fudis-form__header__actions">
+        <ng-container *ngTemplateOutlet="_headerActions!.templateRef" />
+      </div>
+    </ng-container>
+    <ng-container *ngIf="_mainContent?.type === 'form'">
+      <div class="fudis-form__content">
+        <ng-container *ngTemplateOutlet="_mainContent!.templateRef" />
+      </div>
+    </ng-container>
+    <ng-container *ngIf="_headerActions?.type === 'form' && _dialogParent">
+      <div class="fudis-form__header__actions__dialog">
+        <ng-container *ngTemplateOutlet="_headerActions!.templateRef" />
+      </div>
+    </ng-container>
   </div>
-  <ng-container *ngIf="_headerActions?.type === 'form' && !_dialogParent">
-    <div class="fudis-form__header__actions">
-      <ng-container *ngTemplateOutlet="_headerActions!.templateRef" />
-    </div>
-  </ng-container>
-  <ng-container *ngIf="_mainContent?.type === 'form'">
-    <div class="fudis-form__content">
-      <ng-container *ngTemplateOutlet="_mainContent!.templateRef" />
-    </div>
-  </ng-container>
-  <ng-container *ngIf="_headerActions?.type === 'form' && _dialogParent">
-    <div class="fudis-form__header__actions__dialog">
-      <ng-container *ngTemplateOutlet="_headerActions!.templateRef" />
-    </div>
-  </ng-container>
 </form>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.html
@@ -49,7 +49,6 @@
               </ng-container>
             </fudis-heading>
           </ng-container>
-
           <ng-container *ngIf="helpText">
             <div [class.fudis-visually-hidden]="_dialogParent">
               <fudis-body-text fudisSpacing [marginBottom]="'xs'">{{ helpText }}</fudis-body-text>
@@ -57,7 +56,6 @@
           </ng-container>
         </div>
       </ng-container>
-
       <ng-container *ngIf="_headerContent">
         <div class="fudis-form__header__main__content">
           <ng-container *ngTemplateOutlet="_headerContent!.templateRef" />

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
@@ -114,14 +114,14 @@ export class FormComponent extends GridApiDirective implements OnInit, AfterCont
 
     if (this._dialogParent) {
       this._dialogParent.closeButtonPositionAbsolute = true;
-      this._dialogParent.dialogFormTitle = this.title;
-      this._dialogParent.dialogFormTitleLevel = this.titleLevel;
+      this._dialogParent.title = this.title;
+      this._dialogParent.titleLevel = this.titleLevel;
       if (this.badge && this.badgeText) {
-        this._dialogParent.dialogFormBadge = this.badge;
-        this._dialogParent.dialogFormBadgeText = this.badgeText;
+        this._dialogParent.badge = this.badge;
+        this._dialogParent.badgeText = this.badgeText;
       }
       if (this.helpText) {
-        this._dialogParent.dialogHelpText = this.helpText;
+        this._dialogParent.helpText = this.helpText;
       }
     }
   }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
@@ -116,6 +116,10 @@ export class FormComponent extends GridApiDirective implements OnInit, AfterCont
       this._dialogParent.closeButtonPositionAbsolute = true;
       this._dialogParent.formTitle = this.title;
       this._dialogParent.formTitleLevel = this.titleLevel;
+      if (this.badge && this.badgeText) {
+        this._dialogParent.formBadge = this.badge;
+        this._dialogParent.formBadgeText = this.badgeText;
+      }
     }
   }
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
@@ -114,11 +114,14 @@ export class FormComponent extends GridApiDirective implements OnInit, AfterCont
 
     if (this._dialogParent) {
       this._dialogParent.closeButtonPositionAbsolute = true;
-      this._dialogParent.formTitle = this.title;
-      this._dialogParent.formTitleLevel = this.titleLevel;
+      this._dialogParent.dialogFormTitle = this.title;
+      this._dialogParent.dialogFormTitleLevel = this.titleLevel;
       if (this.badge && this.badgeText) {
-        this._dialogParent.formBadge = this.badge;
-        this._dialogParent.formBadgeText = this.badgeText;
+        this._dialogParent.dialogFormBadge = this.badge;
+        this._dialogParent.dialogFormBadgeText = this.badgeText;
+      }
+      if (this.helpText) {
+        this._dialogParent.dialogHelpText = this.helpText;
       }
     }
   }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
@@ -114,6 +114,8 @@ export class FormComponent extends GridApiDirective implements OnInit, AfterCont
 
     if (this._dialogParent) {
       this._dialogParent.closeButtonPositionAbsolute = true;
+      this._dialogParent.formTitle = this.title;
+      this._dialogParent.formTitleLevel = this.titleLevel;
     }
   }
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.scss
@@ -17,7 +17,7 @@
 
   &__errors {
     display: flex;
-    transform: translateX(calc(-1 * spacing.$spacing-xs));
+    transform: translateX(calc(-1 * spacing.$spacing-xxs));
     opacity: 0;
     height: spacing.$spacing-xs;
     animation-name: delay-appearance;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/dialog/dialog.service.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/dialog/dialog.service.ts
@@ -71,7 +71,11 @@ export class FudisDialogService {
    */
   private static _createConfig(userConfig: MatDialogConfig<any> = {}): MatDialogConfig<any> {
     const overridableOptions = { hasBackdrop: true, disableClose: true, autoFocus: false };
-    const forcedOptions = { enterAnimationDuration: 0, panelClass: 'fudis-dialog-panel' };
+    const forcedOptions = {
+      enterAnimationDuration: 0,
+      exitAnimationDuration: 0,
+      panelClass: 'fudis-dialog-panel',
+    };
     return { ...overridableOptions, ...userConfig, ...forcedOptions };
   }
 }


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-274

Bugs fixed:
- Dialog Scroll bar overlapping scrollable content
     1. Moved button outside of dialog content
- Dialog Close button overlapping scrollable content
     1. Moved button outside of dialog content
- Fudis-validation-error-message alert icon crop
- Dialog close frame transitions

Refactored Dialog with form to have same header layout as dialog without form. 
- If form has a dialog as a parent, all heading inputs are passed to dialog component
- In dialog, form heading is hidden, but left to ensure screenreader experience
- Contrary dialog heading is hidden from screen readers, but shown for visual supported users. 

Note: Eventhough screenreaders are informed about form title, focus is not programmatically moved to header as it should in dialog component.