### PR TITLE
[Spacing Classes, DL docs]: Few fixes

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/_index.scss
+++ b/ngx-fudis/projects/ngx-fudis/_index.scss
@@ -20,6 +20,7 @@
 @forward "./src/lib/foundations/grid/tokens.scss";
 @forward "./src/lib/foundations/grid/mixins.scss";
 @forward "./src/lib/foundations/spacing/tokens.scss";
+@forward "./src/lib/foundations/spacing/classes.scss";
 @forward "./src/lib/foundations/typography/tokens.scss";
 @forward "./src/lib/foundations/typography/mixins.scss";
 @forward "./src/lib/foundations/utilities/classes.scss";

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/description-list/description-list-docs.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/description-list/description-list-docs.mdx
@@ -33,14 +33,14 @@ Term and Details content is passed through `textContent` Input property.
 <fudis-dd [textContent]="'Here is the Details element text'" />`}
 />
 
-Term element has also `subHeading` Input for adding optional sub-heading between Term and Details elements. Single Description List Item can have multiple Details elements if necessary.
+Details element has also `subHeading` Input for adding optional sub-heading between Term and Details elements. Single Description List Item can have multiple Details elements if necessary.
 
 <Source
   code={`
 <fudis-dl>
   <fudis-dl-item>
-  <fudis-dt [subHeading]="'I am Term sub heading'" [textContent]="'I am the main Term text content'" />
-  <fudis-dd [textContent]="'I am first Details element'" />
+  <fudis-dt [textContent]="'I am the main Term text content'" />
+  <fudis-dd [subHeading]="'I am Details Sub heading'" [textContent]="'I am first Details element'" />
   <fudis-dd [textContent]="'I am second Details element'" />
   <fudis-dd [textContent]="'I am third Details element'" />
 </fudis-dl-item>
@@ -87,7 +87,7 @@ Set in your `fudis-dd` element `lang` attribute to tell which translation it rep
   code={`
 <fudis-dl>
   <fudis-dl-item>
-    <fudis-dt [subHeading]="'I am Term sub heading'" [textContent]="'Example Languages'" />
+    <fudis-dt [textContent]="'Example Languages'" />
     <fudis-dd [lang]="'en'" [textContent]="'This is in English'" />
     <fudis-dd [lang]="'fi'" [textContent]="'Tämä on suomeksi'" />
     <fudis-dd [lang]="'sv'" [textContent]="'Den här är på Svenska'" />


### PR DESCRIPTION
- Included Spacing classes file as forwarded file in _index.scss
- Fixed Documentation of Description List Sub-heading usage