### PR TITLE
[Form, ErrorSummary]: Remove errorSummaryLinkType

### DIFF
--- a/ngx-fudis/projects/dev/src/app/components/formExamples.component.html
+++ b/ngx-fudis/projects/dev/src/app/components/formExamples.component.html
@@ -9,7 +9,6 @@
     </ng-template>
     <ng-template fudisContent type="expandable">
       <fudis-form
-        [errorSummaryLinkType]="'onClick'"
         [errorSummaryVisible]="errorSummaryVisible"
         [title]="'Form title here hello'"
         [errorSummaryHelpText]="'There were some errors'"

--- a/ngx-fudis/projects/dev/src/app/dialog-test/dialog-test-content/dialog-test-form.component.ts
+++ b/ngx-fudis/projects/dev/src/app/dialog-test/dialog-test-content/dialog-test-form.component.ts
@@ -20,7 +20,6 @@ type MyForm = {
     <fudis-dialog [size]="'sm'">
       <fudis-dialog-content>
         <fudis-form
-          [errorSummaryLinkType]="'onClick'"
           [title]="'Dialog with fudis-form'"
           [errorSummaryHelpText]="'You did not fill all the required information'"
           [level]="2"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.docs.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.docs.mdx
@@ -165,7 +165,7 @@ class SimpleDialogComponent {
 
 ## Fudis Form inside Dialog
 
-When using Form inside Dialog, wrap the Form inside `fudis-dialog-content` and use it normally. Meaning, add all the necessary Error Summary properties, such as `errorSummaryLinkType` and `errorSummaryHelpText`. Also add `title` and `level`, this title will be the title of the dialog and have initial focus when dialog is opened with keyboard.
+When using Form inside Dialog, wrap the Form inside `fudis-dialog-content` and use it normally. Meaning, add all the necessary Error Summary properties, such as `errorSummaryHelpText`. Also add `title` and `level`, this title will be the title of the dialog and have initial focus when dialog is opened with keyboard.
 
 In `fudisContent` template add form components and in `fudisActions` template add action button(s). Unlike normal form, where buttons are positioned on top of the form, **these action buttons will be positioned at the bottom** after the form content, in order to follow dialog look and feel.
 
@@ -182,7 +182,6 @@ In `fudisContent` template add form components and in `fudisActions` template ad
 					<fudis-form>
 						[title]="'Dialog with fudis-form'"
 						[level]="2"
-						[errorSummaryLinkType]="'href'"
 						[errorSummaryHelpText]="'You need to fill up the information.'">
 						<ng-template fudisContent [type]="'form'">
 							<fudis-fieldset [label]="'Question about your power animal'">

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.stories.ts
@@ -66,7 +66,6 @@ class DialogLaucherComponent {
         <fudis-form
           [title]="'Dialog with fudis-form'"
           [level]="2"
-          [errorSummaryLinkType]="'onClick'"
           [errorSummaryHelpText]="'You need to fill up the information.'"
         >
           <ng-template fudisContent [type]="'form'">

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.html
@@ -13,31 +13,13 @@
             </ng-container>
             <ul class="fudis-error-summary__error-list">
               <li class="fudis-error-summary__error-list__item" *ngFor="let error of errors">
-                <ng-container *ngIf="linkType === 'router'">
-                  <fudis-link
-                    [link]="'.'"
-                    [fragmentId]="error.id"
-                    [title]="error.message"
-                    [color]="'primary-dark'"
-                  ></fudis-link>
-                </ng-container>
-                <ng-container *ngIf="linkType === 'href'">
-                  <fudis-link
-                    [size]="'md'"
-                    [href]="'#' + error.id"
-                    [title]="error.message"
-                    [color]="'primary-dark'"
-                  ></fudis-link>
-                </ng-container>
-                <ng-container *ngIf="linkType === 'onClick'">
-                  <fudis-link
-                    (handleClick)="handleErrorClick($event, error.id)"
-                    [size]="'md'"
-                    [href]="'#'"
-                    [title]="error.message"
-                    [color]="'primary-dark'"
-                  ></fudis-link>
-                </ng-container>
+                <fudis-link
+                  (handleClick)="handleErrorClick($event, error.id)"
+                  [size]="'md'"
+                  [href]="'#'"
+                  [title]="error.message"
+                  [color]="'primary-dark'"
+                />
               </li>
             </ul>
           </div>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.spec.ts
@@ -30,7 +30,6 @@ import { TextInputComponent } from '../text-input/text-input.component';
 import { SpacingDirective } from '../../../directives/spacing/spacing.directive';
 import { SectionComponent } from '../../section/section.component';
 import { ExpandableComponent } from '../../expandable/expandable.component';
-import { FudisFormErrorSummaryLink } from '../../../types/forms';
 import { LinkDirective } from '../../../directives/link/link.directive';
 
 @Component({
@@ -40,7 +39,6 @@ import { LinkDirective } from '../../../directives/link/link.directive';
     [level]="1"
     [title]="'Example Form with Error Summary'"
     [id]="'unique-form-example-1'"
-    [errorSummaryLinkType]="errorSummaryLinkType"
     [errorSummaryHelpText]="'There were errors you need to fix'"
     [errorSummaryVisible]="errorSummaryVisible"
   >
@@ -83,8 +81,6 @@ class MockFormComponent {
   constructor(public errorSummaryService: FudisErrorSummaryService) {}
 
   @ViewChild('formRef') formRef: FormComponent;
-
-  errorSummaryLinkType: FudisFormErrorSummaryLink;
 
   errorSummaryVisible: boolean = false;
 
@@ -156,7 +152,6 @@ describe('ErrorSummaryComponent', () => {
 
     wrapperFixture = TestBed.createComponent(MockFormComponent);
     wrapperComponent = wrapperFixture.componentInstance;
-    wrapperComponent.errorSummaryLinkType = 'router';
     wrapperComponent.errorSummaryService.setUpdateStrategy('reloadOnly');
     wrapperFixture.autoDetectChanges();
     wrapperComponent.reloadErrors();
@@ -170,35 +165,6 @@ describe('ErrorSummaryComponent', () => {
       expect(renderedHelpText.textContent).toBe(
         'Attention:\u00A0There were errors you need to fix',
       );
-    });
-
-    it('should have Fudis Link attributes correctly with router link', () => {
-      const linkElementFragment = wrapperFixture.nativeElement
-        .querySelector('ul li fudis-link a')
-        .getAttribute('ng-reflect-fragment');
-
-      const linkElementHref = wrapperFixture.nativeElement
-        .querySelector('ul li fudis-link a')
-        .getAttribute('href');
-
-      expect(linkElementFragment).toEqual('fudis-text-input-1');
-      expect(linkElementHref).toEqual('/#fudis-text-input-1');
-    });
-
-    it('should have Fudis Link attributes correctly with href link', () => {
-      wrapperComponent.errorSummaryLinkType = 'href';
-      wrapperFixture.detectChanges();
-
-      const linkElementFragment = wrapperFixture.nativeElement
-        .querySelector('ul li fudis-link a')
-        .getAttribute('ng-reflect-fragment');
-
-      const linkElementHref = wrapperFixture.nativeElement
-        .querySelector('ul li fudis-link a')
-        .getAttribute('href');
-
-      expect(linkElementFragment).toEqual(null);
-      expect(linkElementHref).toEqual('#fudis-text-input-1');
     });
 
     it('should remove errors dynamically without reload', () => {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.ts
@@ -13,7 +13,6 @@ import {
   FudisFormErrorSummaryObject,
   FudisFormErrorSummaryList,
   FudisFormErrorSummarySection,
-  FudisFormErrorSummaryLink,
 } from '../../../types/forms';
 import { FudisTranslationService } from '../../../services/translation/translation.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -70,11 +69,6 @@ export class ErrorSummaryComponent implements AfterViewInit {
    * Id of parent Form component
    */
   @Input({ required: true }) formId: string;
-
-  /**
-   * Type of the clickable error link
-   */
-  @Input() linkType: FudisFormErrorSummaryLink = 'router';
 
   /**
    * Additional text for screen readers added before help text. E.g. "Attention". Comparable for "alert" icon included in Error Summary.

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.stories.ts
@@ -23,7 +23,6 @@ import { excludeAllRegex } from '../../../utilities/storybook';
     [level]="1"
     [title]="'Example Form with Error Summary'"
     [id]="id"
-    [errorSummaryLinkType]="'onClick'"
     [errorSummaryHelpText]="
       'Toggle live remove button to see errors disappear when input value is corrected'
     "

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.html
@@ -59,7 +59,6 @@
       <ng-container *ngIf="_formElement !== undefined && errorSummaryVisible">
         <fudis-error-summary
           [formId]="id"
-          [linkType]="errorSummaryLinkType"
           [parentComponent]="_formElement"
           [helpText]="errorSummaryHelpText"
         />

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.spec.ts
@@ -38,7 +38,6 @@ import { LinkComponent } from '../../link/link.component';
     [helpText]="'Some help for the form'"
     [badge]="badge"
     [badgeText]="badgeText"
-    [errorSummaryLinkType]="'href'"
     [errorSummaryHelpText]="'There were errors you need to fix'"
     [errorSummaryVisible]="errorSummaryVisible"
   >

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
@@ -17,7 +17,6 @@ import { ActionsDirective } from '../../../directives/content-projection/actions
 import { ContentDirective } from '../../../directives/content-projection/content/content.directive';
 import { GridApiDirective } from '../../../directives/grid/grid-api/grid-api.directive';
 import { FudisBadgeVariant } from '../../../types/miscellaneous';
-import { FudisFormErrorSummaryLink } from '../../../types/forms';
 import { DialogComponent } from '../../dialog/dialog.component';
 import { FudisInternalErrorSummaryService } from '../../../services/form/error-summary/internal-error-summary.service';
 
@@ -96,11 +95,6 @@ export class FormComponent extends GridApiDirective implements OnInit, AfterCont
    * Set Error Summary visibility manually. Usually set true on form submit with Button binded with 'fudisFormSubmit' directive.
    */
   @Input() errorSummaryVisible: boolean = false;
-
-  /**
-   * Type of the clickable error link in Error Summary. If your App uses Angular Router, use default value 'router'. Otherwise use 'onClick'.
-   */
-  @Input() errorSummaryLinkType: FudisFormErrorSummaryLink = 'router';
 
   /**
    * HTML FormElement

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.docs.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.docs.mdx
@@ -76,8 +76,6 @@ See badge variants from [Badge Documentation](/docs/components-badge--documentat
 
 `errorSummaryHelpText`: Mandatory helper text displayed as describing guidance text for the Error Summary.
 
-`errorSummaryLinkType`: Type of the clickable links redirecting and moving focus to invalid form field. Default value `router` is for applications using Angular Router. If application does not use Angular Router, `onClick` or `href` values can be used.
-
 More about [Error Summary](/docs/components-form-error-summary--documentation) and [Error Summary Service](/docs/services-error-summary--documentation).
 
 ## Code Example

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.stories.ts
@@ -7,7 +7,6 @@ import { BehaviorSubject } from 'rxjs';
 import {
   FudisSelectOption,
   FudisRadioButtonOption,
-  FudisFormErrorSummaryLink,
   FudisCheckboxGroupFormGroup,
   // FudisDateRangeItem,
 } from '../../../types/forms';
@@ -42,7 +41,6 @@ import { fudisSpacingArray } from '../../../types/spacing';
       <fudis-form
         [level]="2"
         [title]="'Form with Text Input'"
-        [errorSummaryLinkType]="'onClick'"
         [errorSummaryVisible]="errorSummaryVisible"
         [errorSummaryHelpText]="errorSummaryHelpText"
       >
@@ -67,7 +65,6 @@ import { fudisSpacingArray } from '../../../types/spacing';
       <fudis-form
         [level]="2"
         [title]="'Form with Text Area'"
-        [errorSummaryLinkType]="'onClick'"
         [errorSummaryVisible]="errorSummaryVisible"
         [errorSummaryHelpText]="errorSummaryHelpText"
       >
@@ -92,7 +89,6 @@ import { fudisSpacingArray } from '../../../types/spacing';
       <fudis-form
         [level]="2"
         [title]="'Form with Checkbox Group'"
-        [errorSummaryLinkType]="'onClick'"
         [errorSummaryVisible]="errorSummaryVisible"
         [errorSummaryHelpText]="errorSummaryHelpText"
       >
@@ -126,7 +122,6 @@ import { fudisSpacingArray } from '../../../types/spacing';
       <!-- <fudis-form
         [level]="2"
         [title]="'Form with Select and Multiselect'"
-        [errorSummaryLinkType]="'onClick'"
         [errorSummaryVisible]="errorSummaryVisible"
         [errorSummaryHelpText]="errorSummaryHelpText"
       >
@@ -238,7 +233,6 @@ class ExampleWithMultipleFormsComponent {
       [title]="title"
       [titleVariant]="titleVariant"
       [helpText]="helpText"
-      [errorSummaryLinkType]="errorSummaryLinkType"
       [errorSummaryHelpText]="errorSummaryHelpText"
       [errorSummaryVisible]="errorSummaryVisible"
     >
@@ -406,7 +400,6 @@ class FormContentExampleComponent implements OnInit {
   @Input() badge: FudisBadgeVariant;
   @Input() badgeText: string;
   @Input() errorSummaryHelpText: string;
-  @Input() errorSummaryLinkType: FudisFormErrorSummaryLink;
   @Input() errorSummaryVisible: boolean;
 
   releaseDate: number = new Date(1991, 4, 1).getTime();
@@ -553,12 +546,6 @@ export default {
         type: 'select',
       },
     },
-    errorSummaryLinkType: {
-      options: ['href', 'router', 'onClick'],
-      control: {
-        type: 'select',
-      },
-    },
   },
 } as Meta;
 
@@ -574,7 +561,6 @@ export const Example: StoryFn<FormComponent> = (args: FormComponent) => ({
     [badge]="badge"
     [badgeText]="badgeText"
     [errorSummaryHelpText]="errorSummaryHelpText"
-    [errorSummaryLinkType]="errorSummaryLinkType"
     [errorSummaryVisible]="errorSummaryVisible"
   />`,
 });
@@ -588,7 +574,6 @@ Example.args = {
   badgeText: 'Example',
   errorSummaryHelpText:
     'There are errors in this form. Please address these before trying to submit again.',
-  errorSummaryLinkType: 'onClick',
   errorSummaryVisible: false,
 };
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/types/forms.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/types/forms.ts
@@ -155,6 +155,4 @@ export const FUDIS_DATE_FORMATS: MatDateFormats = {
   },
 };
 
-export type FudisFormErrorSummaryLink = 'router' | 'href' | 'onClick';
-
 export type FudisFormErrorSummaryUpdateStrategy = 'reloadOnly' | 'all' | 'onRemove';


### PR DESCRIPTION
Jira ticket: https://funidata.atlassian.net/browse/DS-312

As router configs vary in Funidata's applications, it was discussed that for Error Summary onClick linkType just seems to work best with all varying configs. So now Error Summary implements just that and other options are removed.

Breaking:
- Form component does not have anymore errorSummaryLinkType input property