### PR TITLE
Fix docs deploy workflow failing when editing release notes programmatically and set low TTL for root index.html cache

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,16 +65,6 @@ jobs:
         run: npm run build -- storybook
       - name: Copy docs to S3 bucket
         run: aws s3 sync static s3://${{ secrets.AWS_S3_BUCKET_NAME }}/v/$VERSION
-      # Saving in a file appears to be the only way to read from env vars when using irongut/editrelease...
-      - name: Generate docs link for release notes
-        run: echo "**Documentation:** [Storybook](https://fudis.funidata.fi/v/${VERSION})" >> release_notes_annex
-      - name: Edit Release
-        uses: irongut/editrelease@v1.2.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          id: ${{ github.event.release.id }}
-          files: release_notes_annex
-          spacing: 2
       - name: Check semver
         id: check-semver
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,4 +79,4 @@ jobs:
           <meta http-equiv='refresh' content='0; url=https://fudis.funidata.fi/v/$VERSION/index.html' />
           </head>
           </html>" > /tmp/index.html
-          aws s3 cp /tmp/index.html s3://${{ secrets.AWS_S3_BUCKET_NAME }}
+          aws s3 cp /tmp/index.html s3://${{ secrets.AWS_S3_BUCKET_NAME }} --cache-control max-age=5


### PR DESCRIPTION
- The 3rd-party `irongut/editrelease` workflow appears to have stopped working somewhere between testing and the last release. It was used to add a link to the deployed documentation to respective release notes. Removed to keep things running smoothly.
- The root index.html file at fudis.funidata.fi was subject to AWS's default cache control (which is between zero seconds and a year at their discretion) causing lingering redirects to a previous documentation version. Now using a TTL of 5 seconds when uploading the redirection index.html. See [AWS docs here](https://docs.aws.amazon.com/whitepapers/latest/build-static-websites-aws/controlling-how-long-amazon-s3-content-is-cached-by-amazon-cloudfront.html#specify-cache-control-headers).