### PR TITLE
[Button]: Remove left padding from buttons with icon and label

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.scss
@@ -21,7 +21,6 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  padding: 0 spacing.$spacing-xs;
   min-width: spacing.$spacing-xxl;
   vertical-align: middle;
 
@@ -37,6 +36,21 @@
 
     &:focus {
       @include focus.focus-generic;
+    }
+  }
+
+  &__label {
+    &--hidden {
+      padding: 0 spacing.$spacing-xs;
+    }
+
+    &--visible {
+      padding: 0 spacing.$spacing-xs;
+
+      /* stylelint-disable-next-line selector-class-pattern */
+      &:has(.fudis-button__icon) {
+        padding: 0 spacing.$spacing-xs 0 0;
+      }
     }
   }
 
@@ -56,15 +70,15 @@
   }
 
   &__size {
-    &-small {
+    &__small {
       min-height: spacing.$spacing-md;
     }
 
-    &-medium {
+    &__medium {
       min-height: spacing.$spacing-lg;
     }
 
-    &-icon-only {
+    &__icon-only {
       padding: 0;
       width: spacing.$spacing-lg;
       min-width: initial;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.spec.ts
@@ -42,7 +42,9 @@ describe('ButtonComponent', () => {
           fixture.detectChanges();
 
           expect(sortClasses(getButton().className)).toEqual(
-            sortClasses(`fudis-button fudis-button__${variant} fudis-button__size-${size}`),
+            sortClasses(
+              `fudis-button fudis-button__label--visible fudis-button__${variant} fudis-button__size__${size}`,
+            ),
           );
         });
       });
@@ -50,7 +52,7 @@ describe('ButtonComponent', () => {
 
     it('should have proper default CSS classes', () => {
       expect(getButton().className).toEqual(
-        'fudis-button fudis-button__primary fudis-button__size-medium',
+        'fudis-button fudis-button__label--visible fudis-button__primary fudis-button__size__medium',
       );
     });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.ts
@@ -167,7 +167,7 @@ export class ButtonComponent extends TooltipApiDirective implements OnChanges, O
     const labelHidden = changes.labelHidden?.currentValue !== changes.labelHidden?.previousValue;
     const ariaLabel = changes.ariaLabel?.currentValue !== changes.ariaLabel?.previousValue;
 
-    if (variant || disabled || size) {
+    if (variant || disabled || size || labelHidden) {
       this._classList.next(this._getClasses());
     }
 
@@ -273,6 +273,20 @@ export class ButtonComponent extends TooltipApiDirective implements OnChanges, O
       this._iconColor.next('primary');
     }
 
-    return ['fudis-button', `fudis-button__size-${this.size}`, `fudis-button__${this.variant}`];
+    if (this.labelHidden) {
+      return [
+        'fudis-button',
+        `fudis-button__size__${this.size}`,
+        `fudis-button__${this.variant}`,
+        `fudis-button__label--hidden`,
+      ];
+    } else {
+      return [
+        'fudis-button',
+        `fudis-button__size__${this.size}`,
+        `fudis-button__${this.variant}`,
+        `fudis-button__label--visible`,
+      ];
+    }
   }
 }


### PR DESCRIPTION
Jira-tikcet: https://funidata.atlassian.net/browse/DS-321

Buttons with icon and label had unnecessary left padding which caused it to look unbalanced when used with buttons without icon and placed on top of each other.