### PR TITLE
[SCSS]: Style import optimizations 

### DIFF
--- a/ngx-fudis/projects/dev/src/styles.scss
+++ b/ngx-fudis/projects/dev/src/styles.scss
@@ -1,9 +1,8 @@
 /* stylelint-disable selector-class-pattern */
 /* stylelint-disable color-no-hex */
 /* stylelint-disable property-disallowed-list */
-@use '@angular/material' as mat;
+
 @use '../../../dist/ngx-fudis/index' as fudis;
-@include mat.core;
 
 * {
   box-sizing: border-box;

--- a/ngx-fudis/projects/documentation/introduction/GettingStarted.stories.mdx
+++ b/ngx-fudis/projects/documentation/introduction/GettingStarted.stories.mdx
@@ -49,15 +49,12 @@ import { NgxFudisModule } from '@funidata/ngx-fudis';
 
 ## 4. Import Core Styles
 
-The core styles from Angular Material and Fudis must be imported to your application's styles for components to work properly.
+The core styles of Fudis must be imported to your application's styles for components to work properly. As Fudis uses Angular Material as its dependency, it is already imported as part of Fudis' main CSS file.
 
 The recommended way is to add following lines your project's root SCSS style file, which is often named `styles.scss` or `index.scss` or similar:
 
 ```
 @use '@funidata/ngx-fudis' as fudis;
-@use '@angular/material' as mat;
-@include mat.core();
-
 ```
 
 ## 5. Define Application's Root Styles

--- a/ngx-fudis/projects/ngx-fudis/src/lib/theme/palette.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/theme/palette.scss
@@ -1,29 +1,29 @@
 @use '@angular/material' as mat;
-@import '../foundations/colors/tokens';
+@use '../foundations/colors/tokens' as colors;
 
 $palette-map-primary: (
-  100: $color-primary-light,
-  500: $color-primary,
-  700: $color-primary-dark,
-  900: $color-primary-extra-dark,
+  100: colors.$color-primary-light,
+  500: colors.$color-primary,
+  700: colors.$color-primary-dark,
+  900: colors.$color-primary-extra-dark,
   contrast: (
-    100: $color-gray-dark,
-    500: $color-white,
-    700: $color-white,
-    900: $color-white,
+    100: colors.$color-gray-dark,
+    500: colors.$color-white,
+    700: colors.$color-white,
+    900: colors.$color-white,
   ),
 );
 $palette-map-accent: (
-  100: $color-red,
-  200: $color-yellow,
-  500: $color-primary,
-  700: $color-green,
+  100: colors.$color-red,
+  200: colors.$color-yellow,
+  500: colors.$color-primary,
+  700: colors.$color-green,
   900: transparent,
   contrast: (
-    100: $color-red-light,
-    200: $color-yellow-light,
-    500: $color-white,
-    700: $color-green-light,
-    900: $color-gray-dark,
+    100: colors.$color-red-light,
+    200: colors.$color-yellow-light,
+    500: colors.$color-white,
+    700: colors.$color-green-light,
+    900: colors.$color-gray-dark,
   ),
 );

--- a/ngx-fudis/projects/ngx-fudis/style.scss
+++ b/ngx-fudis/projects/ngx-fudis/style.scss
@@ -2,15 +2,7 @@
 * This file is for Storybook
 */
 
-@use '@angular/material' as mat;
-@use './src/lib/foundations/typography/mixins.scss' as typography;
-
-// Fudis theme import
-@import './src/lib/theme/component-themes-to-apply';
-
-// Import font files globally
-@import './src/lib/assets/fonts/fonts';
-@import './src/lib/foundations/utilities/classes';
+@use './index' as fudis;
 
 :root {
   --fudis-rem-multiplier: 1;
@@ -43,7 +35,7 @@ a.sbdocs {
 }
 
 tr td p.fudis-table-caption {
-  @include typography.table-caption();
+  @include fudis.table-caption();
 }
 
 .storybook {


### PR DESCRIPTION
Jira-ticket: https://funidata.atlassian.net/browse/DS-380

BREAKING CHANGE:
- Application can remove now previously instructed lines from their main CSS file: 
`@use '@angular/material' as mat;`
`@include mat.core();`
unless application has their own additional ngMaterial uses outside Fudis.

Although style bundle of Fudis has worked well so far, it had unnecessary "double imports" on some styles. Biggest bundle bloater came from Fudis +  Angular Material imports. Instructions and Storybook have been now adjusted to avoid double import of ngMaterial.

This is marked as Breaking Change, as previously we have instructed applications to import both Fudis and ngMaterial in the root style file, but now importing ngMaterial should be unnecessary.
