### PR TITLE
[SelectBase]: Undefined inputRef error

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-base/select-base.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-base/select-base.directive.ts
@@ -707,7 +707,9 @@ export class SelectBaseDirective extends ControlComponentBaseDirective implement
         this._clickFromIcon);
 
     if (this._clickFromIcon) {
-      this._focusToSelectInput();
+      if (!this.control.disabled) {
+        this._focusToSelectInput();
+      }
     }
   }
 }


### PR DESCRIPTION
When clicking disabled Select's chevron or search icon it caused `Cannot read properties of undefined (reading inputRef)` error. To avoid this, added disabled control check for the mouseUp event listener.