### PR TITLE
[TextFieldComponentBaseDirective]: New internal Directive and nullControlOnEmptyString property

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.ts
@@ -1,12 +1,4 @@
-import {
-  ChangeDetectorRef,
-  Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnInit,
-  Output,
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import { FudisInputSize, FudisRadioButtonChangeEvent } from '../../../types/forms';
 import { hasRequiredValidator } from '../../../utilities/form/getValidators';
 import { FudisIdService } from '../../../services/id/id.service';
@@ -24,11 +16,7 @@ export class RadioButtonGroupComponent
   extends ControlComponentBaseDirective
   implements OnInit, OnChanges
 {
-  constructor(
-    _changeDetectorRef: ChangeDetectorRef,
-    _focusService: FudisFocusService,
-    _idService: FudisIdService,
-  ) {
+  constructor(_focusService: FudisFocusService, _idService: FudisIdService) {
     super(_idService, _focusService);
 
     this._updateValueAndValidityTrigger.pipe(takeUntilDestroyed()).subscribe(() => {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.ts
@@ -32,7 +32,7 @@ export class TextAreaComponent
   }
 
   /**
-   * FormControl for text-area
+   * FormControl binded to the HTML textarea element
    */
   @Input({ required: true }) override control: FormControl<string | null | number>;
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { FudisInputSize } from '../../../types/forms';
 import { FudisIdService } from '../../../services/id/id.service';
 import { FudisFocusService } from '../../../services/focus/focus.service';
 import {
@@ -10,15 +9,17 @@ import {
 } from '../../../utilities/form/getValidators';
 import { FudisComponentChanges } from '../../../types/miscellaneous';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { BehaviorSubject } from 'rxjs';
-import { ControlComponentBaseDirective } from '../../../directives/form/control-component-base/control-component-base.directive';
+import { TextFieldComponentBaseDirective } from '../../../directives/form/text-field-component-base/text-field-component-base.directive';
 
 @Component({
   selector: 'fudis-text-area',
   templateUrl: './text-area.component.html',
   styleUrls: ['./text-area.component.scss'],
 })
-export class TextAreaComponent extends ControlComponentBaseDirective implements OnInit, OnChanges {
+export class TextAreaComponent
+  extends TextFieldComponentBaseDirective
+  implements OnInit, OnChanges
+{
   constructor(_focusService: FudisFocusService, _idService: FudisIdService) {
     super(_idService, _focusService);
     this._updateValueAndValidityTrigger.pipe(takeUntilDestroyed()).subscribe(() => {
@@ -35,38 +36,19 @@ export class TextAreaComponent extends ControlComponentBaseDirective implements 
    */
   @Input({ required: true }) override control: FormControl<string | null | number>;
 
-  /**
-   * Text Area size
-   */
-  @Input() size: FudisInputSize = 'lg';
-
-  /**
-   * Min length for HTML attribute
-   */
-  protected _minLength = new BehaviorSubject<number | null>(null);
-
-  /**
-   * Max length for HTML attribute and for character indicator in guidance
-   */
-  protected _maxLength = new BehaviorSubject<number | null>(null);
-
   ngOnInit(): void {
     this._setComponentId('text-area');
     this._updateValueAndValidityTrigger.next();
-
-    /**
-     * TODO: write test
-     */
-    this.control.valueChanges.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((value) => {
-      if (typeof value === 'string' && value.trim() === '') {
-        this.control.setValue(null);
-      }
-    });
+    this._setControlValueSubscription();
   }
 
   ngOnChanges(changes: FudisComponentChanges<TextAreaComponent>): void {
     if (changes.control?.currentValue !== changes.control?.previousValue) {
       this._applyControlUpdateCheck();
+    }
+
+    if (changes.nullControlOnEmptyString?.currentValue !== changes.control?.previousValue) {
+      this._setControlValueSubscription();
     }
   }
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.spec.ts
@@ -7,6 +7,7 @@ import { GuidanceComponent } from '../guidance/guidance.component';
 import { FudisInputSize, FudisInputType } from '../../../types/forms';
 import { FudisValidators } from '../../../utilities/form/validators';
 import { getElement } from '../../../utilities/tests/utilities';
+import { SimpleChange } from '@angular/core';
 
 const textInputControl: FormControl = new FormControl('');
 
@@ -110,6 +111,40 @@ describe('TextInputComponent', () => {
 
       expect(component.control.value).toEqual('210');
       expect(component.control.invalid).toBeTruthy();
+    });
+
+    it('should set value as null, if empty string is passed as value', () => {
+      component.control.patchValue('');
+
+      expect(component.control.value).toEqual(null);
+
+      component.control.patchValue('  ');
+
+      expect(component.control.value).toEqual(null);
+    });
+
+    it('should not set value as null, if empty string is passed as value', () => {
+      const previousValue = component.nullControlOnEmptyString;
+
+      component.nullControlOnEmptyString = false;
+
+      component.ngOnChanges({
+        nullControlOnEmptyString: new SimpleChange(
+          previousValue,
+          component.nullControlOnEmptyString,
+          true,
+        ),
+      });
+
+      expect(component.control.value).toEqual(null);
+
+      component.control.patchValue('');
+
+      expect(component.control.value).toEqual('');
+
+      component.control.patchValue('  ');
+
+      expect(component.control.value).toEqual('  ');
     });
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.ts
@@ -46,7 +46,7 @@ export class TextInputComponent
   }
 
   /**
-   * FormControl for text-input
+   * FormControl binded to the HTML input element
    */
   @Input({ required: true }) override control: FormControl<string | null | number>;
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.ts
@@ -1,6 +1,6 @@
-import { Component, Input, OnInit, ChangeDetectorRef, OnChanges } from '@angular/core';
+import { Component, Input, OnInit, OnChanges } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { FudisInputSize, FudisInputType } from '../../../types/forms';
+import { FudisInputType } from '../../../types/forms';
 import { FudisIdService } from '../../../services/id/id.service';
 import { FudisFocusService } from '../../../services/focus/focus.service';
 import {
@@ -12,20 +12,19 @@ import {
 } from '../../../utilities/form/getValidators';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FudisComponentChanges } from '../../../types/miscellaneous';
+import { TextFieldComponentBaseDirective } from '../../../directives/form/text-field-component-base/text-field-component-base.directive';
 import { BehaviorSubject } from 'rxjs';
-import { ControlComponentBaseDirective } from '../../../directives/form/control-component-base/control-component-base.directive';
 
 @Component({
   selector: 'fudis-text-input',
   templateUrl: './text-input.component.html',
   styleUrls: ['./text-input.component.scss'],
 })
-export class TextInputComponent extends ControlComponentBaseDirective implements OnInit, OnChanges {
-  constructor(
-    _focusService: FudisFocusService,
-    _changeDetectorRef: ChangeDetectorRef,
-    _idService: FudisIdService,
-  ) {
+export class TextInputComponent
+  extends TextFieldComponentBaseDirective
+  implements OnInit, OnChanges
+{
+  constructor(_focusService: FudisFocusService, _idService: FudisIdService) {
     super(_idService, _focusService);
     this._updateValueAndValidityTrigger.pipe(takeUntilDestroyed()).subscribe(() => {
       if (this.control) {
@@ -52,24 +51,9 @@ export class TextInputComponent extends ControlComponentBaseDirective implements
   @Input({ required: true }) override control: FormControl<string | null | number>;
 
   /**
-   * Available sizes for the input. Recommended size for number input is 'sm'.
-   */
-  @Input() size: FudisInputSize = 'lg';
-
-  /**
    * Type of the input - defaults to 'text'
    */
   @Input() type: FudisInputType = 'text';
-
-  /**
-   * Max length for HTML attribute and for character indicator in guidance
-   */
-  protected _maxLength = new BehaviorSubject<number | null>(null);
-
-  /**
-   * Min length for HTML attribute
-   */
-  protected _minLength = new BehaviorSubject<number | null>(null);
 
   /**
    * Max number for number input HTML attribute
@@ -84,15 +68,7 @@ export class TextInputComponent extends ControlComponentBaseDirective implements
   ngOnInit(): void {
     this._setComponentId('text-input');
     this._updateValueAndValidityTrigger.next();
-
-    /**
-     * TODO: write test
-     */
-    this.control.valueChanges.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((value) => {
-      if (typeof value === 'string' && value.trim() === '') {
-        this.control.setValue(null);
-      }
-    });
+    this._setControlValueSubscription();
   }
 
   ngOnChanges(changes: FudisComponentChanges<TextInputComponent>): void {
@@ -102,6 +78,10 @@ export class TextInputComponent extends ControlComponentBaseDirective implements
 
     if (changes.type?.currentValue !== changes.type?.previousValue) {
       this._updateValueAndValidityTrigger.next();
+    }
+
+    if (changes.nullControlOnEmptyString?.currentValue !== changes.control?.previousValue) {
+      this._setControlValueSubscription();
     }
   }
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/text-field-component-base/text-field-component-base.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/text-field-component-base/text-field-component-base.directive.spec.ts
@@ -1,0 +1,27 @@
+import { TestBed } from '@angular/core/testing';
+import { FudisIdService } from '../../../services/id/id.service';
+import { TextFieldComponentBaseDirective } from './text-field-component-base.directive';
+import { FudisFocusService } from '../../../services/focus/focus.service';
+
+describe('TextFieldComponentBaseDirective', () => {
+  let focusService: FudisFocusService;
+  let idService: FudisIdService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [],
+      providers: [FudisIdService, FudisFocusService],
+      imports: [],
+    });
+
+    idService = TestBed.inject(FudisIdService);
+    focusService = TestBed.inject(FudisFocusService);
+  });
+
+  it('should create an instance', () => {
+    TestBed.runInInjectionContext(() => {
+      const directive = new TextFieldComponentBaseDirective(idService, focusService);
+      expect(directive).toBeTruthy();
+    });
+  });
+});

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/text-field-component-base/text-field-component-base.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/text-field-component-base/text-field-component-base.directive.ts
@@ -1,0 +1,54 @@
+import { Directive, Input } from '@angular/core';
+import { ControlComponentBaseDirective } from '../control-component-base/control-component-base.directive';
+import { FudisFocusService } from '../../../services/focus/focus.service';
+import { FudisIdService } from '../../../services/id/id.service';
+import { BehaviorSubject, Subscription } from 'rxjs';
+import { FudisInputSize } from '../../../types/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+@Directive({
+  selector: '[fudisTextFieldComponentBase]',
+})
+export class TextFieldComponentBaseDirective extends ControlComponentBaseDirective {
+  constructor(_idService: FudisIdService, _focusService: FudisFocusService) {
+    super(_idService, _focusService);
+  }
+
+  /**
+   * Available sizes for the input. Recommended size for number input is 'sm'.
+   */
+  @Input() size: FudisInputSize = 'lg';
+
+  /**
+   * If user clears the input field, set FormControl value to null instead of empty string
+   */
+  @Input() nullControlOnEmptyString: boolean = true;
+
+  /**
+   * Max length for HTML attribute and for character indicator in guidance
+   */
+  protected _maxLength = new BehaviorSubject<number | null>(null);
+
+  /**
+   * Min length for HTML attribute
+   */
+  protected _minLength = new BehaviorSubject<number | null>(null);
+
+  protected _subscription: Subscription;
+
+  protected _setControlValueSubscription(): void {
+    if (this.nullControlOnEmptyString) {
+      if (!this._subscription) {
+        this._subscription = this.control.valueChanges
+          .pipe(takeUntilDestroyed(this._destroyRef))
+          .subscribe((value) => {
+            if (typeof value === 'string' && value.trim() === '') {
+              this.control.setValue(null);
+            }
+          });
+      }
+    } else {
+      this._subscription?.unsubscribe();
+    }
+  }
+}

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/text-field-component-base/text-field-component-base.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/text-field-component-base/text-field-component-base.directive.ts
@@ -15,27 +15,33 @@ export class TextFieldComponentBaseDirective extends ControlComponentBaseDirecti
   }
 
   /**
-   * Available sizes for the input. Recommended size for number input is 'sm'.
+   * Width of the input field.
    */
   @Input() size: FudisInputSize = 'lg';
 
   /**
-   * If user clears the input field, set FormControl value to null instead of empty string
+   * If user clears the input field, set FormControl value to null instead of empty string.
    */
   @Input() nullControlOnEmptyString: boolean = true;
 
   /**
-   * Max length for HTML attribute and for character indicator in guidance
+   * Max length for HTML attribute and for character indicator in guidance.
    */
   protected _maxLength = new BehaviorSubject<number | null>(null);
 
   /**
-   * Min length for HTML attribute
+   * Min length for HTML attribute.
    */
   protected _minLength = new BehaviorSubject<number | null>(null);
 
+  /**
+   * Subscription to listen to control's value changes
+   */
   protected _subscription: Subscription;
 
+  /**
+   * Depending on input prop 'nullControlOnEmptyString' either subscribe or unsubscribe to control's value changes
+   */
   protected _setControlValueSubscription(): void {
     if (this.nullControlOnEmptyString) {
       if (!this._subscription) {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/ngx-fudis.module.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/ngx-fudis.module.ts
@@ -106,6 +106,7 @@ import { LinkDirective } from './directives/link/link.directive';
 import { NotificationsDirective } from './directives/content-projection/notifications/notifications.directive';
 import { SelectBaseDirective } from './components/form/select/common/select-base/select-base.directive';
 import { SelectOptionBaseDirective } from './components/form/select/common/select-option-base/select-option-base.directive';
+import { TextFieldComponentBaseDirective } from './directives/form/text-field-component-base/text-field-component-base.directive';
 import { TooltipDirective } from './directives/tooltip/tooltip.directive';
 
 /**
@@ -199,8 +200,9 @@ import { FudisTranslationService } from './services/translation/translation.serv
     SelectGroupComponent,
     SelectOptionBaseDirective,
     SelectOptionComponent,
-    TextInputComponent,
     TextAreaComponent,
+    TextFieldComponentBaseDirective,
+    TextInputComponent,
     TooltipDirective,
     ValidatorErrorMessageComponent,
     SelectIconsComponent,


### PR DESCRIPTION
With TextInput and TextArea, if user clears the input field, it will set the FormControl value as null instead of an empty string. Client application has now need for not setting the value as null and accepting empty string as control's value.

This PR adds new `nullControlOnEmptyString` property to TextInput and TextArea, which prevents automatic nulling of control's value.

Internally also refactored TextArea and TextInput to inherit new TextFieldComponentBaseDirective to avoid duplicate code, as components share lots of same logic and variables etc.

In following PR we should write more throughout tests to this new Directive, although through TextInput, TextArea and e2e tests most of the functionality is quite well already covered.