### PR TITLE
[AlertGroup]: Missing documentation about template usage

### DIFF
--- a/ngx-fudis/projects/dev/src/app/app.component.html
+++ b/ngx-fudis/projects/dev/src/app/app.component.html
@@ -1,7 +1,5 @@
 <ng-container *transloco="let t">
   <div class="root-style">
-    <fudis-alert-group />
-
     <fudis-grid [columns]="4" [classes]="'fudis-mt-lg'">
       <fudis-grid-item [columns]="'3 / 4'" [alignSelfX]="'end'" [alignSelfY]="'end'">
         <fudis-body-text>1 rem = {{ visibleRemValue }}px</fudis-body-text>
@@ -142,5 +140,6 @@
         <a fudisLink href="example.com" [external]="true" [title]="'Promo link'"></a>
       </ng-template>
     </fudis-footer>
+    <fudis-alert-group />
   </div>
 </ng-container>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/alert/alert.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/alert/alert.mdx
@@ -11,7 +11,7 @@ Alert Group Component displays list of toaster-like Alert Components with four v
 
 ## Usage Guidelines
 
-First, add `<fudis-alert-group />` HTML tag in the application template, preferably somewhere up in the application's DOM, e.g. `app.component.html`.
+First, add `<fudis-alert-group />` HTML tag in the application template, preferably as the bottom element in `app.component.html`.
 Note that Alerts will position themselves at the very top of their container, meaning they might overlap the application navigation element, which should be fixed manually by setting custom CSS `top` value as needed in the application side.
 Also, make sure that the custom CSS does not affect Alerts in Dialogs, where they should always be on top because Dialogs have backdrop.
 
@@ -83,7 +83,7 @@ Alerts are reloaded to the DOM each time dialog is opened and closed.
 
 ### Alert Variants
 
-`danger` and `warning` variants are communicated to screen readers, as they have html attribute of `role='alert'`. Other variants have `role='status'`. Focus does not change even if new alert appears.
+All Alerts are communicated to screen readers when appearing for the first time, but with different roles. `danger` and `warning` variants have html attribute of `role='alert'`, other variants have `role='status'`. Focus does not change even if new alert appears.
 
 ### Closing Alert
 
@@ -95,9 +95,8 @@ When user closes an alert, focus will move automatically to the last alert in th
 
 ### Other Mentionable Accessibility Details
 
-- Focusable elements inside alert have visible focus state
-- Danger and warning alerts are communicated to user using `role='alert'` attribute
-- Alert Group is wrapped inside a `section` element which has an automatic `aria-label` describing its content. E.g. _'Notifications - Number of notifications: 5'_
+- Danger and warning alerts will interrupt the user's current activity
+- Alert Group is wrapped inside a `section` element which has an automatic `aria-label` describing its content, e.g. _'Notifications - Number of notifications: 5'_
 
 ## Properties
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/alert/alert.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/alert/alert.mdx
@@ -9,6 +9,11 @@ import { AlertGroupComponent } from "./alert-group/alert-group.component.ts";
 
 Alert Group Component displays list of toaster-like Alert Components with four variants: `success`, `info`, `warning` and `danger.` These variants are the same ones as with [Notification Component](/docs/components-notification--documentation).
 
+## Usage Guidelines
+
+First, add `<fudis-alert-group />` HTML tag in the application template, preferably somewhere up in the application's DOM, e.g. `app.component.html`.
+Note that Alerts will position themselves at the very top of their container, meaning they might overlap the application navigation element, which should be fixed manually by setting the CSS `top` value as needed in the application side.
+
 ## Adding and Dismissing Alerts
 
 Alert Group listens to `FudisAlertService` where application or UI sends information about adding or dismissing alerts.

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/alert/alert.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/alert/alert.mdx
@@ -12,7 +12,8 @@ Alert Group Component displays list of toaster-like Alert Components with four v
 ## Usage Guidelines
 
 First, add `<fudis-alert-group />` HTML tag in the application template, preferably somewhere up in the application's DOM, e.g. `app.component.html`.
-Note that Alerts will position themselves at the very top of their container, meaning they might overlap the application navigation element, which should be fixed manually by setting the CSS `top` value as needed in the application side.
+Note that Alerts will position themselves at the very top of their container, meaning they might overlap the application navigation element, which should be fixed manually by setting custom CSS `top` value as needed in the application side.
+Also, make sure that the custom CSS does not affect Alerts in Dialogs, where they should always be on top because Dialogs have backdrop.
 
 ## Adding and Dismissing Alerts
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.html
@@ -1,4 +1,3 @@
-<fudis-alert-group [insideDialog]="true" />
 <div class="fudis-dialog fudis-dialog__size__{{ size }}" [attr.id]="_id">
   <fudis-button
     *ngIf="_closeLabel | async as closeLabel"
@@ -15,3 +14,4 @@
   </fudis-button>
   <ng-content></ng-content>
 </div>
+<fudis-alert-group [insideDialog]="true" />


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-355

- Added documentation for using `<fudis-alert-group />` in the application template.
- Moved AlertGroup to the bottom element of Dialog Component