### PR TITLE
[Datepicker, Tooltip]: Angular Material based components not reflecting all styles correctly in customer app

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/ngMaterial-theme.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/ngMaterial-theme.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-max-compound-selectors */
 /* stylelint-disable @stylistic/indentation */
 /* stylelint-disable declaration-no-important */
 /* stylelint-disable selector-not-notation */
@@ -11,11 +12,13 @@
 @use '../../../../foundations/borders/mixins.scss' as borders;
 @use '../../../../foundations/spacing/tokens.scss' as spacing;
 @use '../../../../foundations/focus/mixins.scss' as focus;
+@use '../../../../foundations/typography/tokens.scss' as typography;
 
 // When navigating calendar pop-up with Tab key, close button appears at the very end. Button does not appear when using mouse.
 .mat-datepicker-close-button {
   text-transform: uppercase !important;
   color: colors.$color-white !important;
+  font-size: typography.$body-text-m-font-size; // Necessary for overwriting font-size in customer app side
 
   &:focus {
     @include focus.focus-generic;
@@ -88,6 +91,8 @@
       & .mat-mdc-icon-button {
         @include colorMixins.bg-color('transparent');
 
+        font-size: typography.$body-text-m-font-size; // Necessary for overwriting font-size in customer app side
+
         &.mat-calendar-next-button,
         &.mat-calendar-previous-button {
           width: spacing.$spacing-xl;
@@ -99,6 +104,26 @@
       & .mat-mdc-button-persistent-ripple.mdc-button__ripple {
         &::before {
           opacity: 0 !important;
+        }
+      }
+    }
+
+    // After M3 update Datepicker calendar's table font-size does not work in customer app side unless we override them
+    & .mat-calendar-table {
+      // Weekday headers
+      .mat-calendar-table-header th {
+        font-size: typography.$body-text-m-font-size;
+      }
+
+      & .mat-calendar-body {
+        // Month abbreviation
+        & .mat-calendar-body-label {
+          font-size: typography.$body-text-m-font-size;
+        }
+
+        // Calendar days
+        & .mat-calendar-body-cell {
+          font-size: typography.$body-text-m-font-size;
         }
       }
     }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/ngMaterial-theme.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/ngMaterial-theme.scss
@@ -18,7 +18,7 @@
 .mat-datepicker-close-button {
   text-transform: uppercase !important;
   color: colors.$color-white !important;
-  font-size: typography.$body-text-m-font-size; // Necessary for overwriting font-size in customer app side
+  font-size: typography.$body-text-md-font-size; // Necessary for overwriting font-size in customer app side
 
   &:focus {
     @include focus.focus-generic;
@@ -91,7 +91,7 @@
       & .mat-mdc-icon-button {
         @include colorMixins.bg-color('transparent');
 
-        font-size: typography.$body-text-m-font-size; // Necessary for overwriting font-size in customer app side
+        font-size: typography.$body-text-md-font-size; // Necessary for overwriting font-size in customer app side
 
         &.mat-calendar-next-button,
         &.mat-calendar-previous-button {
@@ -112,18 +112,18 @@
     & .mat-calendar-table {
       // Weekday headers
       .mat-calendar-table-header th {
-        font-size: typography.$body-text-m-font-size;
+        font-size: typography.$body-text-md-font-size;
       }
 
       & .mat-calendar-body {
         // Month abbreviation
         & .mat-calendar-body-label {
-          font-size: typography.$body-text-m-font-size;
+          font-size: typography.$body-text-md-font-size;
         }
 
         // Calendar days
         & .mat-calendar-body-cell {
-          font-size: typography.$body-text-m-font-size;
+          font-size: typography.$body-text-md-font-size;
         }
       }
     }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/tooltip/ngMaterial-theme.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/tooltip/ngMaterial-theme.scss
@@ -3,6 +3,7 @@
 
 @use '../../foundations/spacing/tokens.scss' as spacing;
 @use '../../foundations/colors/tokens.scss' as colors;
+@use '../../foundations/typography/mixins.scss' as typography;
 
 mat-tooltip-component .mat-tooltip-handset {
   margin: spacing.$spacing-xs;
@@ -10,6 +11,8 @@ mat-tooltip-component .mat-tooltip-handset {
 
 mat-tooltip-component {
   .mat-mdc-tooltip .mdc-tooltip__surface {
+    @include typography.body-text-md-regular; // Necessary for overwriting typography in customer app side
+
     background-color: colors.$color-gray-dark;
     letter-spacing: normal;
   }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/tooltip/ngMaterial-theme.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/tooltip/ngMaterial-theme.scss
@@ -11,7 +11,7 @@ mat-tooltip-component .mat-tooltip-handset {
 
 mat-tooltip-component {
   .mat-mdc-tooltip .mdc-tooltip__surface {
-    @include typography.body-text-md-regular; // Necessary for overwriting typography in customer app side
+    @include typography.body-text-sm-regular; // Necessary for overwriting typography in customer app side
 
     background-color: colors.$color-gray-dark;
     letter-spacing: normal;


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-355

Certain typography styles did not reflect correctly in customer (Sisu) application side. This might be due to Material 3 update where most of the typography configs were removed and M3 did not have clear instructions how to set up custom typography for individual components.

To fix the issue, some typography styles are overwritten in Datepicker and Tooltip components'  respective `ngMaterial-theme.scss` files. These changes should not effect the components in any way in Fudis.