### PR TITLE
[Maintenance]: Missing information in npmjs website

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/package.json
+++ b/ngx-fudis/projects/ngx-fudis/package.json
@@ -10,6 +10,15 @@
       "sass": "./src/lib/theme/fudis-theme.scss"
     }
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/funidata/fudis.git"
+  },
+  "bugs": {
+    "url": "https://github.com/funidata/fudis/issues"
+  },
+  "author": "Funidata Ltd",
+  "homepage": "https://funidata.github.io/fudis/main/",
   "peerDependencies": {
     "@angular/cdk": "^18.2.8",
     "@angular/common": "^18.2.7",

--- a/ngx-fudis/projects/ngx-fudis/package.json
+++ b/ngx-fudis/projects/ngx-fudis/package.json
@@ -14,6 +14,12 @@
     "type": "git",
     "url": "git+https://github.com/funidata/fudis.git"
   },
+  "keywords": [
+    "funidata",
+    "design-system",
+    "component-library",
+    "angular-components"
+  ],
   "bugs": {
     "url": "https://github.com/funidata/fudis/issues"
   },

--- a/package.json
+++ b/package.json
@@ -23,16 +23,8 @@
     "fudis-release": "scripts/release.sh",
     "format:check": "prettier --check ."
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/funidata/fudis.git"
-  },
   "author": "Funidata Ltd",
   "license": "CC-BY-NC-SA-4.0",
-  "bugs": {
-    "url": "https://github.com/funidata/fudis/issues"
-  },
-  "homepage": "https://funidata.github.io/fudis/main/",
   "devDependencies": {
     "prettier": "^3.2.5"
   }


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-356

https://www.npmjs.com/package/@funidata/ngx-fudis did not list **repository** nor **homepage** information in the info sidepanel.

- Moved _repository_, _bugs_ and _homepage_ from root `package.json` to projects/ngx-fudis `package.json`
- Copied _author_ to be in both `package.json` files
- Added keywords