### PR TITLE
[Services]: General singleton service adjustments

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/alert/alert-group/alert-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/alert/alert-group/alert-group.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
-import { MockComponent } from 'ng-mocks';
 import { AlertGroupComponent } from './alert-group.component';
 import { FudisDialogService } from '../../../services/dialog/dialog.service';
 import { BodyTextComponent } from '../../typography/body-text/body-text.component';
@@ -11,9 +10,6 @@ import { IconComponent } from '../../icon/icon.component';
 import { getElement, sortClasses } from '../../../utilities/tests/utilities';
 import { BehaviorSubject } from 'rxjs';
 import { SimpleChange } from '@angular/core';
-import { FudisIdService } from '../../../services/id/id.service';
-import { FudisTranslationService } from '../../../services/translation/translation.service';
-import { FudisFocusService } from '../../../services/focus/focus.service';
 
 describe('AlertGroupComponent', () => {
   let component: AlertGroupComponent;
@@ -24,18 +20,10 @@ describe('AlertGroupComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MatDialogModule],
-      declarations: [
-        AlertGroupComponent,
-        AlertComponent,
-        BodyTextComponent,
-        MockComponent(IconComponent),
-      ],
+      declarations: [AlertGroupComponent, AlertComponent, BodyTextComponent, IconComponent],
       providers: [
         FudisDialogService,
         FudisAlertService,
-        FudisIdService,
-        FudisTranslationService,
-        FudisFocusService,
         {
           provide: MatDialogRef,
           useValue: {},

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/alert/alert/alert.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/alert/alert/alert.component.spec.ts
@@ -15,8 +15,6 @@ import { LinkDirective } from '../../../directives/link/link.directive';
 import { BehaviorSubject } from 'rxjs';
 import { Component } from '@angular/core';
 import { FudisFocusService } from '../../../services/focus/focus.service';
-import { FudisIdService } from '../../../services/id/id.service';
-import { FudisTranslationService } from '../../../services/translation/translation.service';
 
 const testMessage = new BehaviorSubject<string>('Test message for alert');
 const testHtmlId = 'test-html-id';
@@ -71,9 +69,6 @@ describe('AlertComponent', () => {
       providers: [
         FudisDialogService,
         FudisAlertService,
-        FudisIdService,
-        FudisFocusService,
-        FudisTranslationService,
         {
           provide: MatDialogRef,
           useValue: {},

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/breadcrumbs/breadcrumbs.component.spec.ts
@@ -4,9 +4,7 @@ import { By } from '@angular/platform-browser';
 import { BreadcrumbsComponent } from './breadcrumbs.component';
 import { IconComponent } from '../icon/icon.component';
 import { BodyTextComponent } from '../typography/body-text/body-text.component';
-import { FudisIdService } from '../../services/id/id.service';
 import { BreadcrumbsItemComponent } from './breadcrumbs-item/breadcrumbs-item.component';
-import { FudisTranslationService } from '../../services/translation/translation.service';
 import { RouterModule } from '@angular/router';
 import { LinkDirective } from '../../directives/link/link.directive';
 import { getElement } from '../../utilities/tests/utilities';
@@ -43,7 +41,6 @@ describe('BreadcrumbsComponent', () => {
         MockComponent,
       ],
       imports: [RouterModule.forRoot([])],
-      providers: [FudisIdService, FudisTranslationService],
     });
 
     fixture = TestBed.createComponent(MockComponent);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.spec.ts
@@ -8,7 +8,6 @@ import {
 } from '../../types/miscellaneous';
 import { getElement, sortClasses } from '../../utilities/tests/utilities';
 import { fudisIconRotateArray } from '../../types/icons';
-import { FudisIdService } from '../../services/id/id.service';
 
 describe('ButtonComponent', () => {
   let component: ButtonComponent;
@@ -17,7 +16,6 @@ describe('ButtonComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ButtonComponent, IconComponent],
-      providers: [FudisIdService],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ButtonComponent);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/description-list/description-list-item/description-list-item-details/description-list-item-details.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/description-list/description-list-item/description-list-item-details/description-list-item-details.component.spec.ts
@@ -5,7 +5,6 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { GridComponent } from '../../../grid/grid/grid.component';
 import { GridDirective } from '../../../../directives/grid/grid/grid.directive';
 import { DescriptionListComponent } from '../../description-list.component';
-import { FudisGridService } from '../../../../services/grid/grid.service';
 import { DescriptionListItemComponent } from '../description-list-item.component';
 import { DescriptionListItemTermComponent } from '../description-list-item-term/description-list-item-term.component';
 import { DescriptionListItemDetailsComponent } from './description-list-item-details.component';
@@ -17,7 +16,6 @@ import { FudisBreakpointService } from '../../../../services/breakpoint/breakpoi
 import { FudisTranslationService } from '../../../../services/translation/translation.service';
 import { getElement } from '../../../../utilities/tests/utilities';
 import { FudisDescriptionListVariant } from '../../../../types/miscellaneous';
-import { FudisIdService } from '../../../../services/id/id.service';
 import { TooltipApiDirective } from '../../../../directives/tooltip/tooltip-api.directive';
 import { TooltipDirective } from '../../../../directives/tooltip/tooltip.directive';
 import { ActionsDirective } from '../../../../directives/content-projection/actions/actions.directive';
@@ -87,12 +85,7 @@ describe('DescriptionListItemDetailsComponent', () => {
         TooltipApiDirective,
         MockDlComponent,
       ],
-      providers: [
-        FudisGridService,
-        FudisIdService,
-        FudisBreakpointService,
-        FudisTranslationService,
-      ],
+      providers: [FudisBreakpointService],
       imports: [MatTooltipModule],
     }).compileComponents();
   });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/description-list/description-list-item/description-list-item-term/description-list-item-term.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/description-list/description-list-item/description-list-item-term/description-list-item-term.component.spec.ts
@@ -5,7 +5,6 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { GridComponent } from '../../../grid/grid/grid.component';
 import { GridDirective } from '../../../../directives/grid/grid/grid.directive';
 import { DescriptionListComponent } from '../../description-list.component';
-import { FudisGridService } from '../../../../services/grid/grid.service';
 import { DescriptionListItemComponent } from '../description-list-item.component';
 import { DescriptionListItemTermComponent } from './description-list-item-term.component';
 import { DescriptionListItemDetailsComponent } from '../description-list-item-details/description-list-item-details.component';
@@ -15,7 +14,6 @@ import { FudisBreakpointService } from '../../../../services/breakpoint/breakpoi
 import { FudisTranslationService } from '../../../../services/translation/translation.service';
 import { getElement } from '../../../../utilities/tests/utilities';
 import { FudisDescriptionListVariant } from '../../../../types/miscellaneous';
-import { FudisIdService } from '../../../../services/id/id.service';
 import { TooltipApiDirective } from '../../../../directives/tooltip/tooltip-api.directive';
 import { TooltipDirective } from '../../../../directives/tooltip/tooltip.directive';
 
@@ -78,12 +76,7 @@ describe('DescriptionListItemTermComponent', () => {
         TooltipApiDirective,
         MockDlComponent,
       ],
-      providers: [
-        FudisGridService,
-        FudisIdService,
-        FudisBreakpointService,
-        FudisTranslationService,
-      ],
+      providers: [FudisBreakpointService],
       imports: [MatTooltipModule],
     }).compileComponents();
   });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/description-list/description-list-item/description-list-item.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/description-list/description-list-item/description-list-item.component.spec.ts
@@ -3,7 +3,6 @@ import { By } from '@angular/platform-browser';
 import { GridComponent } from '../../grid/grid/grid.component';
 import { GridDirective } from '../../../directives/grid/grid/grid.directive';
 import { DescriptionListComponent } from '../description-list.component';
-import { FudisGridService } from '../../../services/grid/grid.service';
 import { DescriptionListItemComponent } from './description-list-item.component';
 import { DescriptionListItemTermComponent } from './description-list-item-term/description-list-item-term.component';
 import { DescriptionListItemDetailsComponent } from './description-list-item-details/description-list-item-details.component';
@@ -12,12 +11,10 @@ import { FudisBreakpointService } from '../../../services/breakpoint/breakpoint.
 import { getElement } from '../../../utilities/tests/utilities';
 import { Component, DebugElement, ViewChild } from '@angular/core';
 import { FudisDescriptionListVariant } from '../../../types/miscellaneous';
-import { FudisIdService } from '../../../services/id/id.service';
 import { LanguageBadgeComponent } from '../../language-badge-group/language-badge/language-badge.component';
 import { TooltipApiDirective } from '../../../directives/tooltip/tooltip-api.directive';
 import { TooltipDirective } from '../../../directives/tooltip/tooltip.directive';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { FudisTranslationService } from '../../../services/translation/translation.service';
 
 @Component({
   selector: 'fudis-mock-dl',
@@ -81,12 +78,7 @@ describe('DescriptionListItemComponent', () => {
         MockDlComponent,
       ],
       imports: [MatTooltipModule],
-      providers: [
-        FudisGridService,
-        FudisIdService,
-        FudisBreakpointService,
-        FudisTranslationService,
-      ],
+      providers: [FudisBreakpointService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/description-list/description-list.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/description-list/description-list.component.spec.ts
@@ -3,7 +3,6 @@ import { By } from '@angular/platform-browser';
 import { GridComponent } from '../grid/grid/grid.component';
 import { GridDirective } from '../../directives/grid/grid/grid.directive';
 import { DescriptionListComponent } from './description-list.component';
-import { FudisGridService } from '../../services/grid/grid.service';
 import { DescriptionListItemComponent } from './description-list-item/description-list-item.component';
 import { DescriptionListItemTermComponent } from './description-list-item/description-list-item-term/description-list-item-term.component';
 import { DescriptionListItemDetailsComponent } from './description-list-item/description-list-item-details/description-list-item-details.component';
@@ -12,8 +11,6 @@ import { FudisBreakpointService } from '../../services/breakpoint/breakpoint.ser
 import { getElement, sortClasses } from '../../utilities/tests/utilities';
 import { Component, DebugElement, SimpleChange } from '@angular/core';
 import { FudisDescriptionListVariant } from '../../types/miscellaneous';
-import { FudisIdService } from '../../services/id/id.service';
-import { FudisTranslationService } from '../../services/translation/translation.service';
 
 @Component({
   selector: 'fudis-mock-dl',
@@ -72,12 +69,7 @@ describe('DescriptionListComponent', () => {
         LanguageBadgeGroupComponent,
         MockDlComponent,
       ],
-      providers: [
-        FudisGridService,
-        FudisIdService,
-        FudisBreakpointService,
-        FudisTranslationService,
-      ],
+      providers: [FudisBreakpointService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.spec.ts
@@ -6,8 +6,6 @@ import { FudisDialogService } from '../../services/dialog/dialog.service';
 import { AlertGroupComponent } from '../alert/alert-group/alert-group.component';
 import { getElement } from '../../utilities/tests/utilities';
 import { fudisDialogSizeArray } from '../../types/miscellaneous';
-import { FudisIdService } from '../../services/id/id.service';
-import { FudisTranslationService } from '../../services/translation/translation.service';
 import { FudisAlertService } from '../../services/alert/alert.service';
 import { IconComponent } from '../icon/icon.component';
 
@@ -22,8 +20,6 @@ describe('DialogComponent', () => {
       imports: [MatDialogModule],
       providers: [
         FudisDialogService,
-        FudisIdService,
-        FudisTranslationService,
         FudisAlertService,
         {
           provide: MatDialogRef,

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dropdown-menu/dropdown-menu-group/dropdown-menu-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dropdown-menu/dropdown-menu-group/dropdown-menu-group.component.spec.ts
@@ -12,7 +12,6 @@ describe('DropdownMenuGroupComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [DropdownMenuGroupComponent, DropdownMenuComponent],
-      providers: [FudisIdService],
     })
       .overrideComponent(DropdownMenuGroupComponent, {
         add: {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dropdown-menu/dropdown-menu-item/dropdown-menu-item.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dropdown-menu/dropdown-menu-item/dropdown-menu-item.component.spec.ts
@@ -5,8 +5,6 @@ import { DropdownMenuItemComponent } from './dropdown-menu-item.component';
 import { DropdownMenuComponent } from '../dropdown-menu.component';
 import { ButtonComponent } from '../../button/button.component';
 import { IconComponent } from '../../icon/icon.component';
-import { FudisIdService } from '../../../services/id/id.service';
-import { FudisTranslationService } from '../../../services/translation/translation.service';
 import { defaultMenuItems } from '../mock_data';
 import { getElement } from '../../../utilities/tests/utilities';
 
@@ -52,7 +50,6 @@ describe('DropdownMenuItemComponent', () => {
         IconComponent,
         MockDropdownMenuComponent,
       ],
-      providers: [FudisIdService, FudisTranslationService],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MockDropdownMenuComponent);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dropdown-menu/dropdown-menu.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dropdown-menu/dropdown-menu.component.spec.ts
@@ -3,8 +3,6 @@ import { DropdownMenuComponent } from './dropdown-menu.component';
 import { ButtonComponent } from '../button/button.component';
 import { DropdownMenuItemComponent } from './dropdown-menu-item/dropdown-menu-item.component';
 import { IconComponent } from '../icon/icon.component';
-import { FudisIdService } from '../../services/id/id.service';
-import { FudisTranslationService } from '../../services/translation/translation.service';
 import { getElement, sortClasses } from '../../utilities/tests/utilities';
 import { fudisInputSizeArray } from '../../types/forms';
 import { fudisDropdownMenuAlignArray } from '../../types/miscellaneous';
@@ -22,7 +20,6 @@ describe('DropdownMenuComponent', () => {
         DropdownMenuComponent,
         IconComponent,
       ],
-      providers: [FudisIdService, FudisTranslationService],
     })
       .overrideComponent(DropdownMenuComponent, {
         add: {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.component.spec.ts
@@ -7,9 +7,7 @@ import { ExpandableComponent } from './expandable.component';
 import { ActionsDirective } from '../../directives/content-projection/actions/actions.directive';
 import { ContentDirective } from '../../directives/content-projection/content/content.directive';
 import { FudisExpandableType } from '../../types/miscellaneous';
-import { FudisIdService } from '../../services/id/id.service';
 import { FudisInternalErrorSummaryService } from '../../services/form/error-summary/internal-error-summary.service';
-import { FudisTranslationService } from '../../services/translation/translation.service';
 
 @Component({
   selector: 'fudis-mock-container',
@@ -72,7 +70,7 @@ describe('ExpandableComponent', () => {
         ButtonComponent,
         IconComponent,
       ],
-      providers: [FudisIdService, FudisInternalErrorSummaryService, FudisTranslationService],
+      providers: [FudisInternalErrorSummaryService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/footer/footer.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/footer/footer.component.spec.ts
@@ -3,7 +3,6 @@ import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { FooterComponent } from './footer.component';
 import { GridComponent } from '../grid/grid/grid.component';
-import { FudisGridService } from '../../services/grid/grid.service';
 import {
   FooterContentLeftDirective,
   FooterContentRightDirective,
@@ -13,8 +12,6 @@ import { IconComponent } from '../icon/icon.component';
 import { FudisBreakpointService } from '../../services/breakpoint/breakpoint.service';
 import { LinkDirective } from '../../directives/link/link.directive';
 import { FudisTranslationService } from '../../services/translation/translation.service';
-import { FudisFocusService } from '../../services/focus/focus.service';
-import { FudisIdService } from '../../services/id/id.service';
 
 @Component({
   selector: 'fudis-mock-footer',
@@ -49,13 +46,7 @@ describe('FooterComponent', () => {
         FooterContentRightDirective,
         MockFooterComponent,
       ],
-      providers: [
-        FudisGridService,
-        FudisBreakpointService,
-        FudisTranslationService,
-        FudisFocusService,
-        FudisIdService,
-      ],
+      providers: [FudisBreakpointService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox-group/checkbox-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox-group/checkbox-group.component.spec.ts
@@ -12,7 +12,6 @@ import {
 } from '../../../types/forms';
 import { FudisGroupValidators } from '../../../utilities/form/groupValidators';
 import { FudisBreakpointService } from '../../../services/breakpoint/breakpoint.service';
-import { FudisGridService } from '../../../services/grid/grid.service';
 import { GridComponent } from '../../grid/grid/grid.component';
 import { GridApiDirective } from '../../../directives/grid/grid-api/grid-api.directive';
 import { GridDirective } from '../../../directives/grid/grid/grid.directive';
@@ -20,10 +19,7 @@ import { IconComponent } from '../../icon/icon.component';
 import { ContentDirective } from '../../../directives/content-projection/content/content.directive';
 import { GuidanceComponent } from '../guidance/guidance.component';
 import { ValidatorErrorMessageComponent } from '../error-message/validator-error-message/validator-error-message.component';
-import { FudisIdService } from '../../../services/id/id.service';
-import { FudisFocusService } from '../../../services/focus/focus.service';
 import { FudisInternalErrorSummaryService } from '../../../services/form/error-summary/internal-error-summary.service';
-import { FudisTranslationService } from '../../../services/translation/translation.service';
 
 const testFormGroup = new FormGroup<FudisCheckboxGroupFormGroup<object>>(
   {
@@ -137,14 +133,7 @@ describe('CheckboxGroupComponent', () => {
         IconComponent,
         ValidatorErrorMessageComponent,
       ],
-      providers: [
-        FudisBreakpointService,
-        FudisGridService,
-        FudisIdService,
-        FudisFocusService,
-        FudisInternalErrorSummaryService,
-        FudisTranslationService,
-      ],
+      providers: [FudisBreakpointService, FudisInternalErrorSummaryService],
       imports: [ReactiveFormsModule],
     }).compileComponents();
   });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox-group/checkbox/checkbox.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox-group/checkbox/checkbox.component.spec.ts
@@ -4,7 +4,6 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { BehaviorSubject } from 'rxjs';
 import { By } from '@angular/platform-browser';
 import { FudisBreakpointService } from '../../../../services/breakpoint/breakpoint.service';
-import { FudisGridService } from '../../../../services/grid/grid.service';
 import { ContentDirective } from '../../../../directives/content-projection/content/content.directive';
 import {
   FudisCheckboxChangeEvent,
@@ -21,10 +20,7 @@ import { GridApiDirective } from '../../../../directives/grid/grid-api/grid-api.
 import { GridDirective } from '../../../../directives/grid/grid/grid.directive';
 import { IconComponent } from '../../../icon/icon.component';
 import { ValidatorErrorMessageComponent } from '../../error-message/validator-error-message/validator-error-message.component';
-import { FudisFocusService } from '../../../../services/focus/focus.service';
 import { FudisInternalErrorSummaryService } from '../../../../services/form/error-summary/internal-error-summary.service';
-import { FudisIdService } from '../../../../services/id/id.service';
-import { FudisTranslationService } from '../../../../services/translation/translation.service';
 
 @Component({
   selector: 'fudis-mock-container',
@@ -104,14 +100,7 @@ describe('CheckboxComponent', () => {
         GuidanceComponent,
         IconComponent,
       ],
-      providers: [
-        FudisBreakpointService,
-        FudisGridService,
-        FudisIdService,
-        FudisTranslationService,
-        FudisFocusService,
-        FudisInternalErrorSummaryService,
-      ],
+      providers: [FudisBreakpointService, FudisInternalErrorSummaryService],
       imports: [ReactiveFormsModule],
     }).compileComponents();
   });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/date-range/date-range.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/date-range/date-range.component.spec.ts
@@ -10,11 +10,8 @@ import { LabelComponent } from '../../label/label.component';
 import { IconComponent } from '../../../icon/icon.component';
 import { GuidanceComponent } from '../../guidance/guidance.component';
 import { ValidatorErrorMessageComponent } from '../../error-message/validator-error-message/validator-error-message.component';
-import { FudisIdService } from '../../../../services/id/id.service';
-import { FudisTranslationService } from '../../../../services/translation/translation.service';
 import { getElement, sortClasses } from '../../../../utilities/tests/utilities';
 import { FudisValidators } from '../../../../utilities/form/validators';
-import { FudisFocusService } from '../../../../services/focus/focus.service';
 import { FudisInternalErrorSummaryService } from '../../../../services/form/error-summary/internal-error-summary.service';
 
 @Component({
@@ -62,12 +59,7 @@ describe('DateRangeComponent', () => {
         MockDateRangeComponent,
         IconComponent,
       ],
-      providers: [
-        FudisIdService,
-        FudisTranslationService,
-        FudisFocusService,
-        FudisInternalErrorSummaryService,
-      ],
+      providers: [FudisInternalErrorSummaryService],
       imports: [
         ReactiveFormsModule,
         MatDatepickerModule,

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.spec.ts
@@ -12,10 +12,7 @@ import { DatepickerComponent } from './datepicker.component';
 import { ValidatorErrorMessageComponent } from '../../error-message/validator-error-message/validator-error-message.component';
 import { getElement, sortClasses } from '../../../../utilities/tests/utilities';
 import { fudisInputSizeArray } from '../../../../types/forms';
-import { FudisIdService } from '../../../../services/id/id.service';
 import { FudisInternalErrorSummaryService } from '../../../../services/form/error-summary/internal-error-summary.service';
-import { FudisFocusService } from '../../../../services/focus/focus.service';
-import { FudisTranslationService } from '../../../../services/translation/translation.service';
 
 describe('DatepickerComponent', () => {
   let component: DatepickerComponent;
@@ -38,12 +35,7 @@ describe('DatepickerComponent', () => {
         MatNativeDateModule,
         BrowserAnimationsModule,
       ],
-      providers: [
-        FudisIdService,
-        FudisTranslationService,
-        FudisInternalErrorSummaryService,
-        FudisFocusService,
-      ],
+      providers: [FudisInternalErrorSummaryService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-message/error-message/error-message.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-message/error-message/error-message.component.spec.ts
@@ -10,10 +10,7 @@ import { TextInputComponent } from '../../text-input/text-input.component';
 import { LabelComponent } from '../../label/label.component';
 import { GuidanceComponent } from '../../guidance/guidance.component';
 import { ValidatorErrorMessageComponent } from '../validator-error-message/validator-error-message.component';
-import { FudisIdService } from '../../../../services/id/id.service';
 import { FudisInternalErrorSummaryService } from '../../../../services/form/error-summary/internal-error-summary.service';
-import { FudisFocusService } from '../../../../services/focus/focus.service';
-import { FudisTranslationService } from '../../../../services/translation/translation.service';
 
 const observableMessage = new BehaviorSubject<string>('Test error message');
 
@@ -77,12 +74,7 @@ describe('ErrorMessageComponent', () => {
         MockComponents(LabelComponent, GuidanceComponent),
       ],
       imports: [ReactiveFormsModule],
-      providers: [
-        FudisFocusService,
-        FudisIdService,
-        FudisInternalErrorSummaryService,
-        FudisTranslationService,
-      ],
+      providers: [FudisInternalErrorSummaryService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-message/validator-error-message/validator-error-message.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-message/validator-error-message/validator-error-message.component.spec.ts
@@ -15,10 +15,7 @@ import { GuidanceComponent } from '../../guidance/guidance.component';
 import { LabelComponent } from '../../label/label.component';
 import { IconComponent } from '../../../icon/icon.component';
 import { getElement } from '../../../../utilities/tests/utilities';
-import { FudisFocusService } from '../../../../services/focus/focus.service';
 import { FudisInternalErrorSummaryService } from '../../../../services/form/error-summary/internal-error-summary.service';
-import { FudisIdService } from '../../../../services/id/id.service';
-import { FudisTranslationService } from '../../../../services/translation/translation.service';
 
 // TODO: write tests for input visible, controlName and variant
 @Component({
@@ -57,12 +54,7 @@ describe('ValidatorErrorMessageComponent', () => {
         LabelComponent,
       ],
       imports: [ReactiveFormsModule],
-      providers: [
-        FudisFocusService,
-        FudisInternalErrorSummaryService,
-        FudisIdService,
-        FudisTranslationService,
-      ],
+      providers: [FudisInternalErrorSummaryService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.spec.ts
@@ -15,9 +15,6 @@ import { HeaderDirective } from '../../../directives/content-projection/header/h
 import { GridDirective } from '../../../directives/grid/grid/grid.directive';
 import { FudisBreakpointService } from '../../../services/breakpoint/breakpoint.service';
 import { FudisInternalErrorSummaryService } from '../../../services/form/error-summary/internal-error-summary.service';
-import { FudisGridService } from '../../../services/grid/grid.service';
-import { FudisIdService } from '../../../services/id/id.service';
-import { FudisTranslationService } from '../../../services/translation/translation.service';
 import { GridComponent } from '../../grid/grid/grid.component';
 import { IconComponent } from '../../icon/icon.component';
 import { NotificationComponent } from '../../notification/notification.component';
@@ -30,7 +27,6 @@ import { SectionComponent } from '../../section/section.component';
 import { ExpandableComponent } from '../../expandable/expandable.component';
 import { LinkDirective } from '../../../directives/link/link.directive';
 import { getElement } from '../../../utilities/tests/utilities';
-import { FudisFocusService } from '../../../services/focus/focus.service';
 
 @Component({
   selector: 'fudis-mock-form-component',
@@ -145,12 +141,8 @@ describe('ErrorSummaryComponent', () => {
       ],
       providers: [
         FudisInternalErrorSummaryService,
-        FudisGridService,
-        FudisIdService,
         FudisBreakpointService,
-        FudisTranslationService,
         FudisErrorSummaryService,
-        FudisFocusService,
       ],
       imports: [ReactiveFormsModule, RouterModule.forRoot([])],
     }).compileComponents();

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/fieldset/fieldset.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/fieldset/fieldset.component.spec.ts
@@ -4,7 +4,6 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { GridComponent } from '../../grid/grid/grid.component';
 import { GridApiDirective } from '../../../directives/grid/grid-api/grid-api.directive';
 import { GridDirective } from '../../../directives/grid/grid/grid.directive';
-import { FudisGridService } from '../../../services/grid/grid.service';
 import { FudisInternalErrorSummaryService } from '../../../services/form/error-summary/internal-error-summary.service';
 import { FudisBreakpointService } from '../../../services/breakpoint/breakpoint.service';
 import { FieldSetComponent } from './fieldset.component';
@@ -21,9 +20,6 @@ import { NotificationsDirective } from '../../../directives/content-projection/n
 import { BodyTextComponent } from '../../typography/body-text/body-text.component';
 import { getElement } from '../../../utilities/tests/utilities';
 import { FudisInputSize } from '../../../types/forms';
-import { FudisTranslationService } from '../../../services/translation/translation.service';
-import { FudisFocusService } from '../../../services/focus/focus.service';
-import { FudisIdService } from '../../../services/id/id.service';
 
 @Component({
   selector: 'fudis-mock-fieldset-component',
@@ -79,14 +75,7 @@ describe('FieldSetComponent', () => {
         TextInputComponent,
         ValidatorErrorMessageComponent,
       ],
-      providers: [
-        FudisGridService,
-        FudisInternalErrorSummaryService,
-        FudisBreakpointService,
-        FudisTranslationService,
-        FudisFocusService,
-        FudisIdService,
-      ],
+      providers: [FudisInternalErrorSummaryService, FudisBreakpointService],
       imports: [ReactiveFormsModule],
     }).compileComponents();
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.spec.ts
@@ -5,8 +5,6 @@ import { FormComponent } from './form.component';
 import { HeadingComponent } from '../../typography/heading/heading.component';
 import { BodyTextComponent } from '../../typography/body-text/body-text.component';
 import { GridDirective } from '../../../directives/grid/grid/grid.directive';
-import { FudisIdService } from '../../../services/id/id.service';
-import { FudisGridService } from '../../../services/grid/grid.service';
 import { FudisBreakpointService } from '../../../services/breakpoint/breakpoint.service';
 import { FudisValidators } from '../../../utilities/form/validators';
 import { FudisErrorSummaryService } from '../../../services/form/error-summary/error-summary.service';
@@ -25,8 +23,6 @@ import { BadgeComponent } from '../../badge/badge.component';
 import { FudisBadgeVariant } from '../../../types/miscellaneous';
 import { LinkDirective } from '../../../directives/link/link.directive';
 import { NotificationComponent } from '../../notification/notification.component';
-import { FudisTranslationService } from '../../../services/translation/translation.service';
-import { FudisFocusService } from '../../../services/focus/focus.service';
 
 @Component({
   selector: 'fudis-mock-form-component',
@@ -104,12 +100,8 @@ describe('FormComponent', () => {
       ],
       providers: [
         FudisBreakpointService,
-        FudisGridService,
-        FudisFocusService,
-        FudisIdService,
         FudisInternalErrorSummaryService,
         FudisErrorSummaryService,
-        FudisTranslationService,
       ],
       imports: [ReactiveFormsModule],
     });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.spec.ts
@@ -2,9 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup } from '@angular/forms';
 import { GuidanceComponent } from './guidance.component';
 import { FudisInternalErrorSummaryService } from '../../../services/form/error-summary/internal-error-summary.service';
-import { FudisIdService } from '../../../services/id/id.service';
 import { ValidatorErrorMessageComponent } from '../error-message/validator-error-message/validator-error-message.component';
-import { FudisTranslationService } from '../../../services/translation/translation.service';
 import { IconComponent } from '../../icon/icon.component';
 import { FudisValidators } from '../../../utilities/form/validators';
 import { getElement, getAllElements } from '../../../utilities/tests/utilities';
@@ -54,7 +52,7 @@ describe('GuidanceComponent', () => {
         ValidatorErrorMessageComponent,
         MockComponent(IconComponent),
       ],
-      providers: [FudisInternalErrorSummaryService, FudisIdService, FudisTranslationService],
+      providers: [FudisInternalErrorSummaryService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/label/label.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/label/label.component.spec.ts
@@ -2,8 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { LabelComponent } from './label.component';
 import { ButtonComponent } from '../../button/button.component';
-import { FudisIdService } from '../../../services/id/id.service';
-import { FudisTranslationService } from '../../../services/translation/translation.service';
 import { IconComponent } from '../../icon/icon.component';
 import { TooltipDirective } from '../../../directives/tooltip/tooltip.directive';
 
@@ -14,7 +12,6 @@ describe('LabelComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [LabelComponent, ButtonComponent, IconComponent, TooltipDirective],
-      providers: [FudisTranslationService, FudisIdService],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LabelComponent);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/localized-text-group/localized-text-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/localized-text-group/localized-text-group.component.spec.ts
@@ -17,8 +17,6 @@ import {
 } from '../../../types/forms';
 import { FudisGroupValidators } from '../../../utilities/form/groupValidators';
 import { FudisTranslationService } from '../../../services/translation/translation.service';
-import { FudisIdService } from '../../../services/id/id.service';
-import { FudisFocusService } from '../../../services/focus/focus.service';
 import { FudisInternalErrorSummaryService } from '../../../services/form/error-summary/internal-error-summary.service';
 
 const values = {
@@ -50,12 +48,7 @@ describe('LocalizedTextGroupComponent', () => {
         SelectIconsComponent,
         IconComponent,
       ],
-      providers: [
-        FudisTranslationService,
-        FudisIdService,
-        FudisFocusService,
-        FudisInternalErrorSummaryService,
-      ],
+      providers: [FudisInternalErrorSummaryService],
       imports: [ReactiveFormsModule],
     }).compileComponents();
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.spec.ts
@@ -10,7 +10,6 @@ import {
 import { RadioButtonComponent } from './radio-button/radio-button.component';
 import { FieldSetComponent } from '../fieldset/fieldset.component';
 import { GuidanceComponent } from '../guidance/guidance.component';
-import { FudisIdService } from '../../../services/id/id.service';
 import { getElement } from '../../../utilities/tests/utilities';
 import { Component } from '@angular/core';
 import { ContentDirective } from '../../../directives/content-projection/content/content.directive';
@@ -18,11 +17,8 @@ import { IconComponent } from '../../icon/icon.component';
 import { ValidatorErrorMessageComponent } from '../error-message/validator-error-message/validator-error-message.component';
 import { FudisValidators } from '../../../utilities/form/validators';
 import { GridDirective } from '../../../directives/grid/grid/grid.directive';
-import { FudisGridService } from '../../../services/grid/grid.service';
 import { FudisBreakpointService } from '../../../services/breakpoint/breakpoint.service';
-import { FudisFocusService } from '../../../services/focus/focus.service';
 import { FudisInternalErrorSummaryService } from '../../../services/form/error-summary/internal-error-summary.service';
-import { FudisTranslationService } from '../../../services/translation/translation.service';
 
 @Component({
   selector: 'fudis-mock-component',
@@ -80,14 +76,7 @@ describe('Basic inputs of Radio Button Group', () => {
         IconComponent,
         ValidatorErrorMessageComponent,
       ],
-      providers: [
-        FudisBreakpointService,
-        FudisIdService,
-        FudisGridService,
-        FudisFocusService,
-        FudisInternalErrorSummaryService,
-        FudisTranslationService,
-      ],
+      providers: [FudisBreakpointService, FudisInternalErrorSummaryService],
       imports: [ReactiveFormsModule],
     }).compileComponents();
   });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button/radio-button.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button/radio-button.component.spec.ts
@@ -1,16 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Component } from '@angular/core';
-import { FudisTranslationService } from '../../../../services/translation/translation.service';
 import { RadioButtonComponent } from './radio-button.component';
-import { FudisIdService } from '../../../../services/id/id.service';
 import { RadioButtonGroupComponent } from '../radio-button-group.component';
 import { FudisRadioButtonChangeEvent, FudisRadioButtonOption } from '../../../../types/forms';
 import { FieldSetComponent } from '../../fieldset/fieldset.component';
 import { ContentDirective } from '../../../../directives/content-projection/content/content.directive';
 import { GridDirective } from '../../../../directives/grid/grid/grid.directive';
 import { GridApiDirective } from '../../../../directives/grid/grid-api/grid-api.directive';
-import { FudisGridService } from '../../../../services/grid/grid.service';
 import { FudisBreakpointService } from '../../../../services/breakpoint/breakpoint.service';
 import { GridComponent } from '../../../grid/grid/grid.component';
 import { IconComponent } from '../../../icon/icon.component';
@@ -19,7 +16,6 @@ import { GuidanceComponent } from '../../guidance/guidance.component';
 import { FudisValidators } from '../../../../utilities/form/validators';
 import { By } from '@angular/platform-browser';
 import { getElement } from '../../../../utilities/tests/utilities';
-import { FudisFocusService } from '../../../../services/focus/focus.service';
 import { FudisInternalErrorSummaryService } from '../../../../services/form/error-summary/internal-error-summary.service';
 
 @Component({
@@ -68,14 +64,7 @@ describe('RadioButtonComponent', () => {
         IconComponent,
         ValidatorErrorMessageComponent,
       ],
-      providers: [
-        FudisIdService,
-        FudisBreakpointService,
-        FudisGridService,
-        FudisTranslationService,
-        FudisFocusService,
-        FudisInternalErrorSummaryService,
-      ],
+      providers: [FudisBreakpointService, FudisInternalErrorSummaryService],
       imports: [ReactiveFormsModule],
     }).compileComponents();
   });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/autocomplete/autocomplete.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/autocomplete/autocomplete.component.spec.ts
@@ -3,10 +3,6 @@ import { SelectAutocompleteComponent } from './autocomplete.component';
 import { ReactiveFormsModule } from '@angular/forms';
 import { getElement } from '../../../../../utilities/tests/utilities';
 
-import { FudisIdService } from '../../../../../services/id/id.service';
-import { FudisTranslationService } from '../../../../../services/translation/translation.service';
-import { FudisFocusService } from '../../../../../services/focus/focus.service';
-
 describe('AutocompleteComponent', () => {
   let component: SelectAutocompleteComponent;
   let fixture: ComponentFixture<SelectAutocompleteComponent>;
@@ -14,7 +10,6 @@ describe('AutocompleteComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [SelectAutocompleteComponent],
-      providers: [FudisFocusService, FudisIdService, FudisTranslationService],
       imports: [ReactiveFormsModule],
     });
     fixture = TestBed.createComponent(SelectAutocompleteComponent);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-base/select-base.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-base/select-base.directive.spec.ts
@@ -9,8 +9,6 @@ import { GuidanceComponent } from '../../../guidance/guidance.component';
 import { LabelComponent } from '../../../label/label.component';
 import { BodyTextComponent } from '../../../../typography/body-text/body-text.component';
 import { SelectDropdownComponent } from '../select-dropdown/select-dropdown.component';
-import { FudisIdService } from '../../../../../services/id/id.service';
-import { FudisTranslationService } from '../../../../../services/translation/translation.service';
 import { ContentDirective } from '../../../../../directives/content-projection/content/content.directive';
 import { SelectOptionComponent } from '../../select/select-option/select-option.component';
 import { MultiselectComponent } from '../../multiselect/multiselect.component';
@@ -18,7 +16,6 @@ import { FudisInputSize, FudisSelectOption, FudisSelectVariant } from '../../../
 import { SelectAutocompleteComponent } from '../autocomplete/autocomplete.component';
 import { ButtonComponent } from '../../../../button/button.component';
 import { MultiselectOptionComponent } from '../../multiselect/multiselect-option/multiselect-option.component';
-import { FudisFocusService } from '../../../../../services/focus/focus.service';
 import { getAllElements, getElement } from '../../../../../utilities/tests/utilities';
 import { MultiselectChipListComponent } from '../../multiselect/multiselect-chip-list/multiselect-chip-list.component';
 import { By } from '@angular/platform-browser';
@@ -105,12 +102,7 @@ describe('SelectBaseDirective', () => {
         BodyTextComponent,
         ButtonComponent,
       ],
-      providers: [
-        FudisFocusService,
-        FudisIdService,
-        FudisTranslationService,
-        FudisInternalErrorSummaryService,
-      ],
+      providers: [FudisInternalErrorSummaryService],
       imports: [ReactiveFormsModule],
     }).compileComponents();
   });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-dropdown/select-dropdown.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-dropdown/select-dropdown.component.spec.ts
@@ -4,8 +4,6 @@ import { SelectDropdownComponent } from './select-dropdown.component';
 import { getElement } from '../../../../../utilities/tests/utilities';
 import { BodyTextComponent } from '../../../../typography/body-text/body-text.component';
 import { FudisSelectVariant } from '../../../../../types/forms';
-import { FudisTranslationService } from '../../../../../services/translation/translation.service';
-import { FudisIdService } from '../../../../../services/id/id.service';
 
 const autocompleteVariants: FudisSelectVariant[] = ['autocompleteDropdown', 'autocompleteType'];
 
@@ -17,7 +15,6 @@ describe('SelectDropdownComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [SelectDropdownComponent, BodyTextComponent],
-      providers: [FudisTranslationService, FudisIdService],
     });
     fixture = TestBed.createComponent(SelectDropdownComponent);
     component = fixture.componentInstance;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-group/select-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-group/select-group.component.spec.ts
@@ -14,7 +14,6 @@ describe('SelectGroupComponent', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         declarations: [SelectGroupComponent, SelectComponent],
-        providers: [FudisIdService],
       })
         .overrideComponent(SelectGroupComponent, {
           add: {
@@ -75,7 +74,6 @@ describe('SelectGroupComponent', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         declarations: [SelectGroupComponent, SelectComponent],
-        providers: [FudisIdService],
       })
         .overrideComponent(SelectGroupComponent, {
           add: {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-icons/select-icons.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-icons/select-icons.component.spec.ts
@@ -1,13 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { SelectIconsComponent } from './select-icons.component';
 import { ButtonComponent } from '../../../../button/button.component';
 import { IconComponent } from '../../../../icon/icon.component';
 import { FudisSelectOption, FudisSelectVariant } from '../../../../../types/forms';
 import { FormControl } from '@angular/forms';
 import { getElement } from '../../../../../utilities/tests/utilities';
-import { FudisTranslationService } from '../../../../../services/translation/translation.service';
-import { FudisIdService } from '../../../../../services/id/id.service';
 
 describe('SelectIconsComponent', () => {
   let component: SelectIconsComponent;
@@ -16,7 +13,6 @@ describe('SelectIconsComponent', () => {
   beforeEach(async () => {
     TestBed.configureTestingModule({
       declarations: [SelectIconsComponent, ButtonComponent, IconComponent],
-      providers: [FudisTranslationService, FudisIdService],
     });
     fixture = TestBed.createComponent(SelectIconsComponent);
     component = fixture.componentInstance;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-option-base/select-option-base.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-option-base/select-option-base.directive.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SelectOptionBaseDirective } from './select-option-base.directive';
 import { SelectGroupComponent } from '../select-group/select-group.component';
 import { SelectComponent } from '../../select/select.component';
-import { FudisTranslationService } from '../../../../../services/translation/translation.service';
 import { SelectOptionComponent } from '../../select/select-option/select-option.component';
 import { Component, ViewChild } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
@@ -16,12 +15,10 @@ import { LabelComponent } from '../../../label/label.component';
 import { SelectAutocompleteComponent } from '../autocomplete/autocomplete.component';
 import { SelectDropdownComponent } from '../select-dropdown/select-dropdown.component';
 import { SelectBaseDirective } from '../select-base/select-base.directive';
-import { FudisIdService } from '../../../../../services/id/id.service';
 import { getAllElements } from '../../../../../utilities/tests/utilities';
 import { By } from '@angular/platform-browser';
 import { SelectIconsComponent } from '../select-icons/select-icons.component';
 import { ButtonComponent } from '../../../../button/button.component';
-import { FudisFocusService } from '../../../../../services/focus/focus.service';
 import { FudisInternalErrorSummaryService } from '../../../../../services/form/error-summary/internal-error-summary.service';
 
 @Component({
@@ -86,13 +83,7 @@ describe('SelectOptionBaseDirective', () => {
         LabelComponent,
         BodyTextComponent,
       ],
-      providers: [
-        FudisIdService,
-        FudisTranslationService,
-        SelectBaseDirective,
-        FudisFocusService,
-        FudisInternalErrorSummaryService,
-      ],
+      providers: [SelectBaseDirective, FudisInternalErrorSummaryService],
       imports: [ReactiveFormsModule],
     }).compileComponents();
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect-option/multiselect-option.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect-option/multiselect-option.component.spec.ts
@@ -12,14 +12,11 @@ import { IconComponent } from '../../../../icon/icon.component';
 import { LabelComponent } from '../../../label/label.component';
 import { GuidanceComponent } from '../../../guidance/guidance.component';
 import { FudisSelectOption } from '../../../../../types/forms';
-import { FudisTranslationService } from '../../../../../services/translation/translation.service';
-import { FudisIdService } from '../../../../../services/id/id.service';
 import { ContentDirective } from '../../../../../directives/content-projection/content/content.directive';
 import { getElement } from '../../../../../utilities/tests/utilities';
 import { defaultOptions } from '../../common/mock_data';
 import { SelectIconsComponent } from '../../common/select-icons/select-icons.component';
 import { ButtonComponent } from '../../../../button/button.component';
-import { FudisFocusService } from '../../../../../services/focus/focus.service';
 import { FudisInternalErrorSummaryService } from '../../../../../services/form/error-summary/internal-error-summary.service';
 
 @Component({
@@ -69,12 +66,7 @@ describe('MultiselectOptionComponent', () => {
         IconComponent,
         LabelComponent,
       ],
-      providers: [
-        FudisIdService,
-        FudisTranslationService,
-        FudisFocusService,
-        FudisInternalErrorSummaryService,
-      ],
+      providers: [FudisInternalErrorSummaryService],
       imports: [ReactiveFormsModule],
     }).compileComponents();
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect.component.spec.ts
@@ -13,9 +13,6 @@ import { MultiselectOptionComponent } from './multiselect-option/multiselect-opt
 import { SelectGroupComponent } from '../common/select-group/select-group.component';
 import { SelectBaseDirective } from '../common/select-base/select-base.directive';
 import { TooltipDirective } from '../../../../directives/tooltip/tooltip.directive';
-import { FudisTranslationService } from '../../../../services/translation/translation.service';
-import { FudisFocusService } from '../../../../services/focus/focus.service';
-import { FudisIdService } from '../../../../services/id/id.service';
 import { FudisSelectOption } from '../../../../types/forms';
 import { getAllElements, getElement } from '../../../../utilities/tests/utilities';
 import { TestAnimalSound, defaultOptions } from '../common/mock_data';
@@ -73,14 +70,7 @@ describe('MultiselectComponent', () => {
         LabelComponent,
         ContentDirective,
       ],
-      providers: [
-        FudisIdService,
-        FudisTranslationService,
-        FudisInternalErrorSummaryService,
-        FudisFocusService,
-        TooltipDirective,
-        SelectBaseDirective,
-      ],
+      providers: [FudisInternalErrorSummaryService, TooltipDirective, SelectBaseDirective],
       imports: [ReactiveFormsModule],
     }).compileComponents();
   });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/select/select-option/select-option.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/select/select-option/select-option.component.spec.ts
@@ -1,10 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { SelectOptionComponent } from './select-option.component';
 import { SelectGroupComponent } from '../../common/select-group/select-group.component';
 import { SelectComponent } from '../select.component';
-import { FudisTranslationService } from '../../../../../services/translation/translation.service';
-import { FudisIdService } from '../../../../../services/id/id.service';
 import { defaultOptions } from '../../common/mock_data';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Component, ViewChild } from '@angular/core';
@@ -20,7 +17,6 @@ import { By } from '@angular/platform-browser';
 import { SelectIconsComponent } from '../../common/select-icons/select-icons.component';
 import { ButtonComponent } from '../../../../button/button.component';
 import { getElement } from '../../../../../utilities/tests/utilities';
-import { FudisFocusService } from '../../../../../services/focus/focus.service';
 import { FudisInternalErrorSummaryService } from '../../../../../services/form/error-summary/internal-error-summary.service';
 
 @Component({
@@ -68,12 +64,7 @@ describe('SelectOptionComponent', () => {
         LabelComponent,
         BodyTextComponent,
       ],
-      providers: [
-        FudisIdService,
-        FudisTranslationService,
-        FudisFocusService,
-        FudisInternalErrorSummaryService,
-      ],
+      providers: [FudisInternalErrorSummaryService],
       imports: [ReactiveFormsModule],
     }).compileComponents();
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/select/select.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/select/select.component.spec.ts
@@ -1,16 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { SelectComponent } from './select.component';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { FudisIdService } from '../../../../services/id/id.service';
 import { GuidanceComponent } from '../../guidance/guidance.component';
 import { IconComponent } from '../../../icon/icon.component';
 import { TooltipDirective } from '../../../../directives/tooltip/tooltip.directive';
 import { LabelComponent } from '../../label/label.component';
 import { TestAnimalSound, defaultOptions } from '../common/mock_data';
 import { SelectBaseDirective } from '../common/select-base/select-base.directive';
-import { FudisTranslationService } from '../../../../services/translation/translation.service';
-import { FudisFocusService } from '../../../../services/focus/focus.service';
 import { SelectAutocompleteComponent } from '../common/autocomplete/autocomplete.component';
 import { SelectDropdownComponent } from '../common/select-dropdown/select-dropdown.component';
 import { BodyTextComponent } from '../../../typography/body-text/body-text.component';
@@ -65,14 +61,7 @@ describe('SelectComponent', () => {
         SelectIconsComponent,
         BodyTextComponent,
       ],
-      providers: [
-        FudisIdService,
-        FudisInternalErrorSummaryService,
-        FudisTranslationService,
-        FudisFocusService,
-        TooltipDirective,
-        SelectBaseDirective,
-      ],
+      providers: [FudisInternalErrorSummaryService, TooltipDirective, SelectBaseDirective],
       imports: [ReactiveFormsModule],
     }).compileComponents();
   });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.spec.ts
@@ -10,10 +10,7 @@ import { ButtonComponent } from '../../button/button.component';
 import { IconComponent } from '../../icon/icon.component';
 import { TooltipDirective } from '../../../directives/tooltip/tooltip.directive';
 import { getElement } from '../../../utilities/tests/utilities';
-import { FudisFocusService } from '../../../services/focus/focus.service';
 import { FudisInternalErrorSummaryService } from '../../../services/form/error-summary/internal-error-summary.service';
-import { FudisIdService } from '../../../services/id/id.service';
-import { FudisTranslationService } from '../../../services/translation/translation.service';
 
 const textAreaControl: FormControl = new FormControl('');
 
@@ -33,12 +30,7 @@ describe('TextAreaComponent', () => {
         TooltipApiDirective,
       ],
       imports: [ReactiveFormsModule],
-      providers: [
-        FudisIdService,
-        FudisFocusService,
-        FudisTranslationService,
-        FudisInternalErrorSummaryService,
-      ],
+      providers: [FudisInternalErrorSummaryService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.spec.ts
@@ -11,10 +11,7 @@ import { getElement } from '../../../utilities/tests/utilities';
 import { SimpleChange } from '@angular/core';
 import { TooltipDirective } from '../../../directives/tooltip/tooltip.directive';
 import { TooltipApiDirective } from '../../../directives/tooltip/tooltip-api.directive';
-import { FudisFocusService } from '../../../services/focus/focus.service';
 import { FudisInternalErrorSummaryService } from '../../../services/form/error-summary/internal-error-summary.service';
-import { FudisIdService } from '../../../services/id/id.service';
-import { FudisTranslationService } from '../../../services/translation/translation.service';
 
 const textInputControl: FormControl = new FormControl('');
 
@@ -34,12 +31,7 @@ describe('TextInputComponent', () => {
         TooltipApiDirective,
       ],
       imports: [ReactiveFormsModule],
-      providers: [
-        FudisIdService,
-        FudisFocusService,
-        FudisInternalErrorSummaryService,
-        FudisTranslationService,
-      ],
+      providers: [FudisInternalErrorSummaryService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid-item/grid-item.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid-item/grid-item.component.spec.ts
@@ -3,7 +3,6 @@ import { Component } from '@angular/core';
 import { MockComponent } from 'ng-mocks';
 import { By } from '@angular/platform-browser';
 import { GridItemComponent } from './grid-item.component';
-import { FudisGridService } from '../../../services/grid/grid.service';
 import { FudisBreakpointService } from '../../../services/breakpoint/breakpoint.service';
 import { FudisBreakpointStyleResponsive } from '../../../types/breakpoints';
 import { FudisGridItemAlignment } from '../../../types/grid';
@@ -48,7 +47,7 @@ describe('GridItemComponent', () => {
         MockComponent(BodyTextComponent),
         MockComponent(ButtonComponent),
       ],
-      providers: [FudisGridService, FudisBreakpointService],
+      providers: [FudisBreakpointService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid/grid.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid/grid.component.spec.ts
@@ -1,7 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { GridComponent } from './grid.component';
-import { FudisGridService } from '../../../services/grid/grid.service';
 import { FudisBreakpointService } from '../../../services/breakpoint/breakpoint.service';
 
 describe('GridComponent', () => {
@@ -11,7 +9,7 @@ describe('GridComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [GridComponent],
-      providers: [FudisGridService, FudisBreakpointService],
+      providers: [FudisBreakpointService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/language-badge-group/language-badge-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/language-badge-group/language-badge-group.component.spec.ts
@@ -7,8 +7,6 @@ import { LanguageBadgeComponent } from './language-badge/language-badge.componen
 import { getAllElements, getElement } from '../../utilities/tests/utilities';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TooltipDirective } from '../../directives/tooltip/tooltip.directive';
-import { FudisTranslationService } from '../../services/translation/translation.service';
-import { FudisIdService } from '../../services/id/id.service';
 
 const providedLanguages: FudisLanguageAbbr[] = ['en', 'fi'];
 
@@ -31,7 +29,6 @@ describe('LanguageBadgeGroupComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [LanguageBadgeGroupComponent],
-      providers: [FudisTranslationService, FudisIdService, FudisTranslationService],
     });
     fixture = TestBed.createComponent(LanguageBadgeGroupComponent);
     component = fixture.componentInstance;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/language-badge-group/language-badge/language-badge.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/language-badge-group/language-badge/language-badge.component.spec.ts
@@ -4,7 +4,6 @@ import { By } from '@angular/platform-browser';
 import { LanguageBadgeComponent } from './language-badge.component';
 import { TooltipDirective } from '../../../directives/tooltip/tooltip.directive';
 import { FudisIdService } from '../../../services/id/id.service';
-import { FudisTranslationService } from '../../../services/translation/translation.service';
 import { getElement } from '../../../utilities/tests/utilities';
 
 describe('LanguageBadgeComponent', () => {
@@ -16,7 +15,6 @@ describe('LanguageBadgeComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [LanguageBadgeComponent, TooltipDirective],
       imports: [MatTooltipModule],
-      providers: [FudisIdService, FudisTranslationService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/nofication.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/nofication.component.spec.ts
@@ -5,7 +5,6 @@ import { FudisNotification } from '../../types/miscellaneous';
 import { getElement } from '../../utilities/tests/utilities';
 import { RouterModule } from '@angular/router';
 import { LinkDirective } from '../../directives/link/link.directive';
-import { FudisTranslationService } from '../../services/translation/translation.service';
 
 describe('NotificationComponent', () => {
   let fixture: ComponentFixture<NotificationComponent>;
@@ -13,7 +12,6 @@ describe('NotificationComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [NotificationComponent, IconComponent, LinkDirective],
-      providers: [FudisTranslationService],
       imports: [RouterModule.forRoot([])],
     }).compileComponents();
   });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/section/section.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/section/section.component.spec.ts
@@ -8,8 +8,6 @@ import { ButtonComponent } from '../button/button.component';
 import { BodyTextComponent } from '../typography/body-text/body-text.component';
 import { NotificationComponent } from '../notification/notification.component';
 import { IconComponent } from '../icon/icon.component';
-import { FudisGridService } from '../../services/grid/grid.service';
-import { FudisIdService } from '../../services/id/id.service';
 import { GridDirective } from '../../directives/grid/grid/grid.directive';
 import { FudisInternalErrorSummaryService } from '../../services/form/error-summary/internal-error-summary.service';
 import { FudisBreakpointService } from '../../services/breakpoint/breakpoint.service';
@@ -25,7 +23,6 @@ import {
   fudisHeadingVariantArray,
 } from '../../types/typography';
 import { getElement, sortClasses } from '../../utilities/tests/utilities';
-import { FudisTranslationService } from '../../services/translation/translation.service';
 
 @Component({
   selector: 'mock-fudis-section',
@@ -81,13 +78,7 @@ describe('SectionComponent', () => {
         SectionComponent,
         TooltipDirective,
       ],
-      providers: [
-        FudisGridService,
-        FudisIdService,
-        FudisInternalErrorSummaryService,
-        FudisBreakpointService,
-        FudisTranslationService,
-      ],
+      providers: [FudisInternalErrorSummaryService, FudisBreakpointService],
       imports: [MatTooltipModule],
     });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/body-text/body-text.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BodyTextComponent } from './body-text.component';
 import { getElement, sortClasses } from '../../../utilities/tests/utilities';
 import { fudisBodyTextArray, fudisTextAlignArray } from '../../../types/typography';
-import { FudisIdService } from '../../../services/id/id.service';
 
 describe('BodyTextComponent', () => {
   let fixture: ComponentFixture<BodyTextComponent>;
@@ -10,7 +9,6 @@ describe('BodyTextComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [BodyTextComponent],
-      providers: [FudisIdService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/heading/heading.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/typography/heading/heading.component.spec.ts
@@ -7,7 +7,6 @@ import {
   fudisHeadingVariantArray,
 } from '../../../types/typography';
 import { FudisTextAlign, fudisTextAlignArray } from '../../../types/typography';
-import { FudisIdService } from '../../../services/id/id.service';
 
 describe('HeadingComponent', () => {
   let component: HeadingComponent;
@@ -16,7 +15,6 @@ describe('HeadingComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [HeadingComponent],
-      providers: [FudisIdService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/dialog/dialog-directives.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/dialog/dialog-directives.spec.ts
@@ -15,8 +15,6 @@ import {
 } from './dialog-directives';
 import { getElement } from '../../utilities/tests/utilities';
 import { AlertGroupComponent } from '../../components/alert/alert-group/alert-group.component';
-import { FudisIdService } from '../../services/id/id.service';
-import { FudisTranslationService } from '../../services/translation/translation.service';
 import { FudisAlertService } from '../../services/alert/alert.service';
 
 @Component({
@@ -71,7 +69,7 @@ describe('DialogDirectives', () => {
         DialogCloseDirective,
         HostComponent,
       ],
-      providers: [FudisDialogService, FudisIdService, FudisTranslationService, FudisAlertService],
+      providers: [FudisDialogService, FudisAlertService],
       imports: [MatDialogModule],
     }).compileComponents();
   });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/control-component-base/control-component-base.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/control-component-base/control-component-base.directive.spec.ts
@@ -8,11 +8,7 @@ describe('ControlComponentBaseDirective', () => {
   let focusService: FudisFocusService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [],
-      providers: [FudisIdService, FudisFocusService],
-      imports: [],
-    });
+    TestBed.configureTestingModule({});
 
     idService = TestBed.inject(FudisIdService);
     focusService = TestBed.inject(FudisFocusService);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/form-common-api/form-common-api.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/form-common-api/form-common-api.directive.spec.ts
@@ -26,11 +26,7 @@ describe('FormCommonApiDirective', () => {
   let focusService: FudisFocusService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [],
-      providers: [FudisIdService, FudisFocusService],
-      imports: [],
-    });
+    TestBed.configureTestingModule({});
 
     idService = TestBed.inject(FudisIdService);
     focusService = TestBed.inject(FudisFocusService);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/group-component-base/group-component-base.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/group-component-base/group-component-base.directive.spec.ts
@@ -8,11 +8,7 @@ describe('GroupComponentBaseDirective', () => {
   let focusService: FudisFocusService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [],
-      providers: [FudisIdService, FudisFocusService],
-      imports: [],
-    });
+    TestBed.configureTestingModule({});
 
     idService = TestBed.inject(FudisIdService);
     focusService = TestBed.inject(FudisFocusService);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/text-field-component-base/text-field-component-base.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/text-field-component-base/text-field-component-base.directive.spec.ts
@@ -8,11 +8,7 @@ describe('TextFieldComponentBaseDirective', () => {
   let idService: FudisIdService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [],
-      providers: [FudisIdService, FudisFocusService],
-      imports: [],
-    });
+    TestBed.configureTestingModule({});
 
     idService = TestBed.inject(FudisIdService);
     focusService = TestBed.inject(FudisFocusService);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/grid/grid-item/grid-item.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/grid/grid-item/grid-item.directive.spec.ts
@@ -3,7 +3,6 @@ import { Component } from '@angular/core';
 import { MockComponent } from 'ng-mocks';
 import { getDirective } from '../../../utilities/tests/utilities';
 import { GridItemDirective } from './grid-item.directive';
-import { FudisGridService } from '../../../services/grid/grid.service';
 import { FudisBreakpointService } from '../../../services/breakpoint/breakpoint.service';
 import { GridComponent } from '../../../components/grid/grid/grid.component';
 import { HeadingComponent } from '../../../components/typography/heading/heading.component';
@@ -49,7 +48,7 @@ describe('GridItemDirective', () => {
         MockComponent(BodyTextComponent),
         MockComponent(ButtonComponent),
       ],
-      providers: [FudisGridService, FudisBreakpointService],
+      providers: [FudisBreakpointService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/grid/grid/grid.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/grid/grid/grid.directive.spec.ts
@@ -12,7 +12,6 @@ import {
 import { HeadingComponent } from '../../../components/typography/heading/heading.component';
 import { BodyTextComponent } from '../../../components/typography/body-text/body-text.component';
 import { ButtonComponent } from '../../../components/button/button.component';
-import { FudisGridService } from '../../../services/grid/grid.service';
 import { FudisBreakpointService } from '../../../services/breakpoint/breakpoint.service';
 import { GridApiDirective } from '../grid-api/grid-api.directive';
 import { GridDirective } from './grid.directive';
@@ -70,7 +69,7 @@ describe('GridDirective', () => {
         MockComponent(BodyTextComponent),
         MockComponent(ButtonComponent),
       ],
-      providers: [FudisGridService, FudisBreakpointService],
+      providers: [FudisBreakpointService],
     }).compileComponents();
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/link/link.directive.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/link/link.directive.spec.ts
@@ -3,9 +3,6 @@ import { Component, ElementRef, SimpleChange, ViewChild } from '@angular/core';
 import { LinkDirective } from './link.directive';
 import { IconComponent } from '../../components/icon/icon.component';
 import { getElement, sortClasses } from '../../utilities/tests/utilities';
-import { FudisFocusService } from '../../services/focus/focus.service';
-import { FudisIdService } from '../../services/id/id.service';
-import { FudisTranslationService } from '../../services/translation/translation.service';
 
 @Component({
   selector: 'fudis-mock-link-directive',
@@ -50,7 +47,6 @@ describe('LinkDirective', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [MockComponent, LinkDirective, IconComponent],
-      providers: [FudisFocusService, FudisIdService, FudisTranslationService],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MockComponent);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/alert/alert.service.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/alert/alert.service.spec.ts
@@ -2,7 +2,6 @@ import { TestBed } from '@angular/core/testing';
 import { FudisAlertService } from './alert.service';
 import { FudisAlert, FudisAlertElement } from '../../types/miscellaneous';
 import { BehaviorSubject } from 'rxjs';
-import { FudisIdService } from '../id/id.service';
 
 describe('FudisAlertService', () => {
   let service: FudisAlertService;
@@ -35,7 +34,7 @@ describe('FudisAlertService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [FudisAlertService, FudisIdService],
+      providers: [FudisAlertService],
     });
     service = TestBed.inject(FudisAlertService);
   });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/dialog/dialog.service.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/dialog/dialog.service.spec.ts
@@ -12,8 +12,6 @@ import {
   DialogContentDirective,
 } from '../../directives/dialog/dialog-directives';
 import { AlertGroupComponent } from '../../components/alert/alert-group/alert-group.component';
-import { FudisIdService } from '../id/id.service';
-import { FudisTranslationService } from '../translation/translation.service';
 import { IconComponent } from '../../components/icon/icon.component';
 import { FudisAlertService } from '../alert/alert.service';
 
@@ -99,8 +97,6 @@ describe('DialogService', () => {
       ],
       providers: [
         FudisDialogService,
-        FudisIdService,
-        FudisTranslationService,
         FudisAlertService,
         {
           provide: MatDialogRef,

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/focus/focus.service.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/focus/focus.service.spec.ts
@@ -4,8 +4,6 @@ import { Component } from '@angular/core';
 import { ButtonComponent } from '../../components/button/button.component';
 import { IconComponent } from '../../components/icon/icon.component';
 import { LinkDirective } from '../../directives/link/link.directive';
-import { FudisIdService } from '../id/id.service';
-import { FudisTranslationService } from '../translation/translation.service';
 
 @Component({
   selector: 'fudis-mock-component',
@@ -45,7 +43,6 @@ describe('FudisFocusService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [MockFocusComponent, ButtonComponent, IconComponent, LinkDirective],
-      providers: [FudisFocusService, FudisIdService, FudisTranslationService],
     });
 
     fixture = TestBed.createComponent(MockFocusComponent);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/focus/focus.service.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/focus/focus.service.ts
@@ -1,7 +1,7 @@
 import { DOCUMENT } from '@angular/common';
 import { Inject, Injectable } from '@angular/core';
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class FudisFocusService {
   constructor(@Inject(DOCUMENT) private _document: Document) {}
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/error-summary.service.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/error-summary.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { FudisErrorSummaryService } from './error-summary.service';
 import { FudisInternalErrorSummaryService } from './internal-error-summary.service';
-import { FudisTranslationService } from '../../translation/translation.service';
 import {
   FudisErrorSummaryNewError,
   FudisErrorSummaryRemoveError,
@@ -14,11 +13,7 @@ describe('ErrorSummaryService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        FudisErrorSummaryService,
-        FudisInternalErrorSummaryService,
-        FudisTranslationService,
-      ],
+      providers: [FudisErrorSummaryService, FudisInternalErrorSummaryService],
     });
     service = TestBed.inject(FudisErrorSummaryService);
     internalService = TestBed.inject(FudisInternalErrorSummaryService);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/internal-error-summary.service.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/internal-error-summary.service.spec.ts
@@ -6,7 +6,6 @@ import {
   FudisErrorSummaryRemoveError,
 } from '../../../types/errorSummary';
 import { FudisInternalErrorSummaryService } from './internal-error-summary.service';
-import { FudisTranslationService } from '../../translation/translation.service';
 
 describe('InternalErrorSummaryService', () => {
   let service: FudisInternalErrorSummaryService;
@@ -70,7 +69,7 @@ describe('InternalErrorSummaryService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [FudisInternalErrorSummaryService, FudisTranslationService],
+      providers: [FudisInternalErrorSummaryService],
     });
 
     service = TestBed.inject(FudisInternalErrorSummaryService);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/grid/grid.service.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/grid/grid.service.spec.ts
@@ -6,7 +6,7 @@ describe('FudisGridService', () => {
   let service: FudisGridService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({ providers: [FudisGridService] });
+    TestBed.configureTestingModule({});
     service = TestBed.inject(FudisGridService);
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/grid/grid.service.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/grid/grid.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Signal, signal } from '@angular/core';
 import { FudisGridProperties } from '../../types/grid';
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class FudisGridService {
   /**
    * Grid values that can be set from application. By default an empty object.

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/id/id.service.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/id/id.service.spec.ts
@@ -155,9 +155,7 @@ describe('FudisIdServiceService', () => {
   };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [FudisIdService],
-    });
+    TestBed.configureTestingModule({});
     idService = TestBed.inject(FudisIdService);
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/id/id.service.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/id/id.service.ts
@@ -9,7 +9,7 @@ import {
   FudisIdDropdownMenuFamily,
 } from '../../types/id';
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class FudisIdService {
   private _idData: FudisIdData = {
     components: {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/translation/translation.service.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/translation/translation.service.spec.ts
@@ -6,7 +6,7 @@ describe('TranslationService', () => {
   let service: FudisTranslationService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({ providers: [FudisTranslationService] });
+    TestBed.configureTestingModule({});
     service = TestBed.inject(FudisTranslationService);
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/translation/translation.service.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/translation/translation.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Signal, signal } from '@angular/core';
 import { FudisTranslationConfig, FudisLanguageAbbr } from '../../types/miscellaneous';
 import { fi, sv, en } from './translationKeys';
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class FudisTranslationService {
   constructor() {}
 


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-378

It was recommended that all services that do not hold any specific component's state could/should be singleton services (`providedIn: 'root'`), provided for the whole application. Angular does tree shaking for these services so unused services are not contained in the build.