### PR TITLE
[DialogService]: add chaining check for Dialog refs

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.component.ts
@@ -50,7 +50,7 @@ export class DialogComponent implements OnDestroy, OnInit {
   private _orderNumber: number;
 
   ngOnInit(): void {
-    this._orderNumber = this._dialogService.dialogsOpen();
+    this._orderNumber = this._dialogService.dialogsOpen().length;
   }
 
   ngOnDestroy(): void {
@@ -61,7 +61,7 @@ export class DialogComponent implements OnDestroy, OnInit {
 
   @HostListener('window:keyup.escape', ['$event'])
   private _handleEscapePress() {
-    if (this._dialogService.dialogsOpen() === this._orderNumber) {
+    if (this._dialogService.dialogsOpen().length === this._orderNumber) {
       this._dialogService.close();
     }
   }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/dialog/dialog.service.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/dialog/dialog.service.spec.ts
@@ -123,13 +123,13 @@ describe('DialogService', () => {
 
   it('should open fudis-dialog with greeting from component to dialog', () => {
     const openDialogSpy = jest.spyOn(service, 'open');
-    expect(service.dialogsOpen()).toEqual(0);
+    expect(service.dialogsOpen().length).toEqual(0);
     component.openTestDialog();
 
     expect(openDialogSpy).toHaveBeenCalledWith(DialogTestContentComponent, {
       data: { greeting: 'Message to dialog!' },
     });
-    expect(service.dialogsOpen()).toEqual(1);
+    expect(service.dialogsOpen().length).toEqual(1);
   });
 
   it('close should close dialog and pass data from dialog to component', () => {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/dialog/dialog.service.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/dialog/dialog.service.ts
@@ -41,7 +41,7 @@ export class FudisDialogService {
    * @param dialogResult Data sent to Component which opened this dialog.
    */
   public close(dialogResult?: any): void {
-    this._dialogRefs[this._dialogRefs.length - 1].close(dialogResult);
+    this._dialogRefs[this._dialogRefs.length - 1]?.close(dialogResult);
   }
 
   /**

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/dialog/dialog.service.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/dialog/dialog.service.ts
@@ -25,9 +25,6 @@ export class FudisDialogService {
       FudisDialogService._createConfig(config),
     );
 
-    console.log('opening');
-    console.log(this.ngMaterialDialog.openDialogs);
-
     return newDialog;
   }
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/dialog/dialog.service.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/dialog/dialog.service.ts
@@ -10,8 +10,6 @@ export class FudisDialogService {
 
   private _dialogOpen = new BehaviorSubject<boolean>(false);
 
-  private _dialogRefs: MatDialogRef<any, any>[] = [];
-
   /**
    * Open new dialog.
    * @param component Component or template to show in the dialog.
@@ -27,11 +25,8 @@ export class FudisDialogService {
       FudisDialogService._createConfig(config),
     );
 
-    this._dialogRefs.push(newDialog);
-
-    newDialog.afterClosed().subscribe(() => {
-      this._dialogRefs.pop();
-    });
+    console.log('opening');
+    console.log(this.ngMaterialDialog.openDialogs);
 
     return newDialog;
   }
@@ -41,7 +36,9 @@ export class FudisDialogService {
    * @param dialogResult Data sent to Component which opened this dialog.
    */
   public close(dialogResult?: any): void {
-    this._dialogRefs[this._dialogRefs.length - 1]?.close(dialogResult);
+    const currentDialogs = this.ngMaterialDialog.openDialogs;
+
+    currentDialogs?.[currentDialogs.length - 1].close(dialogResult);
   }
 
   /**
@@ -67,10 +64,10 @@ export class FudisDialogService {
 
   /**
    *
-   * @returns Amount of dialogs opened
+   * @returns Currently open Dialogs
    */
-  public dialogsOpen(): number {
-    return this._dialogRefs.length;
+  public dialogsOpen(): MatDialogRef<any, any>[] {
+    return this.ngMaterialDialog.openDialogs;
   }
 
   /**


### PR DESCRIPTION
Slack discussion: https://sisudev.slack.com/archives/C8UPGUKJL/p1733147123932459

App developers encountered error, as they are asking Dialog service to close Dialogs which do not exist anymore, so added optional chaining check to Dialog Refs. Also replaced changed DialogService to use ngMaterial's `openDialogs` array.