### PR TITLE
[Localized Text Group]: Type change

### DIFF
--- a/ngx-fudis/projects/dev/src/app/components/formExamples.component.ts
+++ b/ngx-fudis/projects/dev/src/app/components/formExamples.component.ts
@@ -17,7 +17,9 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { defaultOptions } from 'projects/ngx-fudis/src/lib/components/form/select/common/mock_data';
 
 interface MyLocalizedTextGroup {
-  [key: string]: FormControl<string | null>;
+  fi: FormControl<string | null>;
+  sv: FormControl<string | null>;
+  en: FormControl<string | null>;
 }
 
 type MyCheckboxGroup = {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-message/error-message/error-message.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-message/error-message/error-message.directive.ts
@@ -31,7 +31,10 @@ import { SelectComponent } from '../../select/select/select.component';
 import { MultiselectComponent } from '../../select/multiselect/multiselect.component';
 import { FudisComponentChanges } from '../../../../types/miscellaneous';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { FudisCheckboxGroupFormGroup } from '../../../../types/forms';
+import {
+  FudisCheckboxGroupFormGroup,
+  FudisLocalizedTextGroupFormGroup,
+} from '../../../../types/forms';
 
 @Directive({
   selector: 'fudis-error-message',
@@ -44,7 +47,11 @@ export class ErrorMessageDirective implements OnInit, OnChanges, OnDestroy {
     @Host() @Optional() private _textInput: TextInputComponent,
     @Host() @Optional() private _textArea: TextAreaComponent,
     @Host() @Optional() private _datePicker: DatepickerComponent,
-    @Host() @Optional() private _LocalizedTextGroup: LocalizedTextGroupComponent,
+    @Host()
+    @Optional()
+    private _LocalizedTextGroup: LocalizedTextGroupComponent<
+      FudisLocalizedTextGroupFormGroup<object>
+    >,
     @Host()
     @Optional()
     private _checkboxGroup: CheckboxGroupComponent<FudisCheckboxGroupFormGroup<object>>,
@@ -118,7 +125,7 @@ export class ErrorMessageDirective implements OnInit, OnChanges, OnDestroy {
    * Possible parent group components to used with Error Message
    */
   private _parentGroup:
-    | LocalizedTextGroupComponent
+    | LocalizedTextGroupComponent<FudisLocalizedTextGroupFormGroup<object>>
     | CheckboxGroupComponent<FudisCheckboxGroupFormGroup<object>>;
 
   /**

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/examples/form-example-with-multiple-forms.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/examples/form-example-with-multiple-forms.component.ts
@@ -4,9 +4,9 @@ import { FormGroup, FormControl } from '@angular/forms';
 import { BehaviorSubject } from 'rxjs';
 import { NgxFudisModule } from '../../../../ngx-fudis.module';
 import {
+  FudisLocalizedTextGroupDefaultFormGroup,
   FudisRadioButtonOption,
   FudisSelectOption,
-  FudisLocalizedTextGroup,
 } from '../../../../types/forms';
 import { FudisValidators } from '../../../../utilities/form/validators';
 import { FudisGroupValidators } from '../../../../utilities/form/groupValidators';
@@ -327,7 +327,7 @@ export class StorybookExampleWithMultipleFormsComponent {
     }),
     formFive: new FormControl(null, FudisValidators.required('No fruit picked! :(')),
     formSix: new FormGroup({
-      oneRequired: new FormGroup<FudisLocalizedTextGroup<object>>(
+      oneRequired: new FormGroup<FudisLocalizedTextGroupDefaultFormGroup>(
         {
           fi: new FormControl<string | null>(null),
           sv: new FormControl<string | null>(null),
@@ -335,7 +335,7 @@ export class StorybookExampleWithMultipleFormsComponent {
         },
         [FudisGroupValidators.oneRequired('Provide name in atleast one language')],
       ),
-      allRequired: new FormGroup<FudisLocalizedTextGroup<object>>({
+      allRequired: new FormGroup<FudisLocalizedTextGroupDefaultFormGroup>({
         fi: new FormControl<string | null>('Lorem ipsum', [
           FudisValidators.required('Missing Finnish description'),
           FudisValidators.maxLength(10, 'Too long Finnish description'),

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/localized-text-group/localized-text-group.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/localized-text-group/localized-text-group.component.html
@@ -15,7 +15,7 @@
         #inputRef
         class="fudis-form-input fudis-localized-text-group__inputs__text"
         [class.fudis-form-input--touched]="
-          formGroup.controls[control.key].touched || formGroup.touched
+          $any(formGroup).controls[control.key].touched || formGroup.touched
         "
         [attr.aria-invalid]="formGroup.invalid || null"
         [attr.aria-label]="
@@ -25,7 +25,7 @@
         "
         [attr.minlength]="_minLength | async"
         [attr.maxlength]="_maxLength | async"
-        [formControl]="formGroup.controls[control.key]"
+        [formControl]="$any(formGroup).controls[control.key]"
         (keyup)="_updateSelectOptions(); handleKeyUp.emit($event)"
         (blur)="handleBlur.emit($event)"
         (focus)="onFocus($event)"
@@ -34,10 +34,10 @@
         [attr.aria-describedby]="id + '_guidance'"
         [attr.required]="(_required | async) || null"
         [attr.aria-disabled]="
-          formGroup.disabled || formGroup.controls[control.key].disabled || disabled || null
+          formGroup.disabled || $any(formGroup).controls[control.key].disabled || disabled || null
         "
         [readonly]="
-          formGroup.disabled || formGroup.controls[control.key].disabled || disabled || null
+          formGroup.disabled || $any(formGroup).controls[control.key].disabled || disabled || null
         "
       />
       <textarea
@@ -45,7 +45,7 @@
         *ngIf="variant === 'text-area' && control.key === _selectControl.value.value"
         class="fudis-form-input fudis-localized-text-group__inputs__area"
         [class.fudis-form-input--touched]="
-          formGroup.controls[control.key].touched || formGroup.touched
+          $any(formGroup).controls[control.key].touched || formGroup.touched
         "
         [attr.aria-invalid]="formGroup.invalid || null"
         [attr.aria-label]="
@@ -55,7 +55,7 @@
         "
         [attr.minlength]="_minLength | async"
         [attr.maxlength]="_maxLength | async"
-        [formControl]="formGroup.controls[control.key]"
+        [formControl]="$any(formGroup).controls[control.key]"
         (keyup)="_updateSelectOptions(); handleKeyUp.emit($event)"
         (blur)="handleBlur.emit($event)"
         (focus)="onFocus($event)"
@@ -63,8 +63,8 @@
         [attr.tabindex]="disabled ? -1 : null"
         [attr.aria-describedby]="id + '_guidance'"
         [attr.required]="(_required | async) || null"
-        [attr.aria-disabled]="formGroup.controls[control.key].disabled || disabled || null"
-        [readonly]="formGroup.controls[control.key].disabled || disabled || null"
+        [attr.aria-disabled]="$any(formGroup).controls[control.key].disabled || disabled || null"
+        [readonly]="$any(formGroup).controls[control.key].disabled || disabled || null"
       >
       </textarea>
     </ng-container>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/localized-text-group/localized-text-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/localized-text-group/localized-text-group.component.spec.ts
@@ -12,8 +12,9 @@ import { SelectIconsComponent } from '../select/common/select-icons/select-icons
 import { IconComponent } from '../../icon/icon.component';
 import {
   fudisInputSizeArray,
-  FudisLocalizedTextGroup,
-  FudisLocalizedTextGroupOptions,
+  FudisLocalizedTextGroupDefaultFormGroup,
+  FudisLocalizedTextGroupFormGroup,
+  FudisLocalizedTextGroupFormGroupOptions,
 } from '../../../types/forms';
 import { FudisGroupValidators } from '../../../utilities/form/groupValidators';
 import { FudisTranslationService } from '../../../services/translation/translation.service';
@@ -33,8 +34,14 @@ const minLength = FudisValidators.minLength(5, 'Min length is 5');
 const maxlength = FudisValidators.maxLength(25, 'Max length is 25');
 
 describe('LocalizedTextGroupComponent', () => {
-  let component: LocalizedTextGroupComponent;
-  let fixture: ComponentFixture<LocalizedTextGroupComponent>;
+  let component: LocalizedTextGroupComponent<
+    FudisLocalizedTextGroupFormGroup<FudisLocalizedTextGroupDefaultFormGroup>
+  >;
+  let fixture: ComponentFixture<
+    LocalizedTextGroupComponent<
+      FudisLocalizedTextGroupFormGroup<FudisLocalizedTextGroupDefaultFormGroup>
+    >
+  >;
   let translationService: FudisTranslationService;
 
   beforeEach(() => {
@@ -56,7 +63,7 @@ describe('LocalizedTextGroupComponent', () => {
     translationService = TestBed.inject(FudisTranslationService);
     component = fixture.componentInstance;
 
-    const formGroup = new FormGroup<FudisLocalizedTextGroup<object>>({
+    const formGroup = new FormGroup<FudisLocalizedTextGroupDefaultFormGroup>({
       fi: new FormControl('', controlRequired),
       sv: new FormControl(''),
       en: new FormControl('', FudisValidators.required('Required in English')),
@@ -155,13 +162,14 @@ describe('LocalizedTextGroupComponent', () => {
       });
 
       it(`should have custom default option in Select`, () => {
-        const formGroupSecond = new FormGroup<FudisLocalizedTextGroup<object>>({
+        // By purpose false type casting, as it would be tedious to either make this component instance to accept two interface types or to just create another whole test component case for this single unit test. So therefore on purpose typecasting falsely to supress TS lint errors.
+        const formGroupSecond = new FormGroup({
           klingon: new FormControl<string | null>(null),
           elvish: new FormControl<string | null>(null),
           dothraki: new FormControl<string | null>(null),
-        });
+        }) as unknown as FormGroup<FudisLocalizedTextGroupDefaultFormGroup>;
 
-        const optionsSecond: FudisLocalizedTextGroupOptions[] = [
+        const optionsSecond: FudisLocalizedTextGroupFormGroupOptions[] = [
           { controlName: 'klingon', label: 'KLI' },
           { controlName: 'elvish', label: 'ELV' },
           { controlName: 'dothraki', label: 'DOT' },

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/localized-text-group/localized-text-group.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/localized-text-group/localized-text-group.component.ts
@@ -9,9 +9,9 @@ import {
 } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import {
-  FudisLocalizedTextGroup,
+  FudisLocalizedTextGroupFormGroup,
   FudisSelectOption,
-  FudisLocalizedTextGroupOptions,
+  FudisLocalizedTextGroupFormGroupOptions,
   FudisInputSize,
 } from '../../../types/forms';
 import { FudisIdService } from '../../../services/id/id.service';
@@ -33,7 +33,7 @@ import { FudisFocusService } from '../../../services/focus/focus.service';
   providers: [FudisDOMUtilitiesService, { provide: 'componentType', useValue: 'label' }],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LocalizedTextGroupComponent
+export class LocalizedTextGroupComponent<T extends FudisLocalizedTextGroupFormGroup<T>>
   extends GroupComponentBaseDirective
   implements OnInit, OnChanges, AfterViewInit
 {
@@ -65,12 +65,12 @@ export class LocalizedTextGroupComponent
   /**
    * FormGroup including controls.
    */
-  @Input({ required: true }) override formGroup: FormGroup<FudisLocalizedTextGroup<object>>;
+  @Input({ required: true }) override formGroup: FormGroup<T>;
 
   /**
    * Option list for language Selection. To pair controls with corresponding Select option, FormControl's name must match with the controlName defined here. E.g. by default "{controlName: 'en', label: 'EN'}" pairs with Form Group's "en: new FormControl('')"
    */
-  @Input() options: FudisLocalizedTextGroupOptions[] = [
+  @Input() options: FudisLocalizedTextGroupFormGroupOptions[] = [
     { controlName: 'fi', label: 'FI' },
     { controlName: 'sv', label: 'SV' },
     { controlName: 'en', label: 'EN' },
@@ -128,8 +128,8 @@ export class LocalizedTextGroupComponent
       let newOption: FudisSelectOption<object> | null = null;
 
       if (
-        this.formGroup.controls[option.controlName].invalid ||
-        !this.formGroup.controls[option.controlName].value
+        this.formGroup.controls[option.controlName as keyof T].invalid ||
+        !this.formGroup.controls[option.controlName as keyof T].value
       ) {
         newOption = {
           value: option.controlName,
@@ -158,7 +158,7 @@ export class LocalizedTextGroupComponent
     const groupRequiredValidator = FudisValidatorUtilities.oneRequiredOrMin(this.formGroup);
 
     const nonEmptyControls = Object.keys(this.formGroup.controls).filter((control) => {
-      return this.formGroup.controls[control].value;
+      return this.formGroup.controls[control as keyof T].value;
     });
 
     if (
@@ -172,7 +172,7 @@ export class LocalizedTextGroupComponent
   }
 
   protected _checkHtmlAttributes(controlName: string): void {
-    const control = this.formGroup.controls[controlName];
+    const control = this.formGroup.controls[controlName as keyof T] as FormControl<string | null>;
 
     this._minLength.next(FudisValidatorUtilities.minLength(control));
     this._maxLength.next(FudisValidatorUtilities.maxLength(control));
@@ -183,7 +183,7 @@ export class LocalizedTextGroupComponent
     this._setComponentId('localized-text-group');
   }
 
-  ngOnChanges(changes: FudisComponentChanges<LocalizedTextGroupComponent>): void {
+  ngOnChanges(changes: FudisComponentChanges<LocalizedTextGroupComponent<T>>): void {
     if (changes.formGroup?.currentValue !== changes.formGroup?.previousValue) {
       this._applyGroupUpdateCheck();
       this._updateSelectOptions();

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/localized-text-group/localized-text-group.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/localized-text-group/localized-text-group.mdx
@@ -88,7 +88,7 @@ The `formGroup` property of this example is defined like this:
 
 <Source
   code={`
-formGroup = new FormGroup<FudisLocalizedTextGroup<object>>({
+formGroup = new FormGroup<T>({
   fi: new FormControl<string | null>(null, [
     FudisValidators.maxLength(15, 'Too long Finnish name'),
   ]),
@@ -111,7 +111,7 @@ The `formGroup` property of this example is defined like this:
 
 <Source
   code={`
-formGroup = new FormGroup<FudisLocalizedTextGroup<object>>({
+formGroup = new FormGroup<T>({
   fi: new FormControl<string | null>(null, [
     FudisValidators.required('Missing superhero name on Finnish.'),
     FudisValidators.minLength(5, 'Too short Finnish name'),

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/localized-text-group/localized-text-group.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/localized-text-group/localized-text-group.mdx
@@ -43,7 +43,7 @@ options = [
 With this default value, the FormGroup should have a following structure:
 
 ```
-formGroup = new FormGroup({
+formGroup = new FormGroup<FudisLocalizedTextGroupDefaultFormGroup>({
   fi: new FormControl<string | null>(null),
   sv: new FormControl<string | null>(null),
   en: new FormControl<string | null>(null),
@@ -67,7 +67,13 @@ options = [
 Then the FormGroup should look like this to match with each selectable option:
 
 ```
-formGroup = new FormGroup({
+interface MyCustomType {
+  klingon: FormControl<string | null>;
+  elvish: FormControl<string | null>;
+  dothraki: FormControl<string | null>;
+}
+
+formGroup = new FormGroup<MyCustomType>({
   klingon: new FormControl<string | null>(null),
   elvish: new FormControl<string | null>(null),
   dothraki: new FormControl<string | null>(null),

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/localized-text-group/localized-text-group.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/localized-text-group/localized-text-group.stories.ts
@@ -5,7 +5,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LocalizedTextGroupComponent } from './localized-text-group.component';
 import { FudisValidators } from '../../../utilities/form/validators';
 import { FudisGroupValidators } from '../../../utilities/form/groupValidators';
-import { fudisInputSizeArray, FudisLocalizedTextGroup } from '../../../types/forms';
+import { fudisInputSizeArray, FudisLocalizedTextGroupDefaultFormGroup } from '../../../types/forms';
 import { LocalizedTextGroupStoryExclude } from '../../../utilities/storybook';
 import docs from './localized-text-group.mdx';
 import { action } from '@storybook/addon-actions';
@@ -49,7 +49,7 @@ export default {
 
 const html = String.raw;
 
-const commonArgs: Partial<LocalizedTextGroupComponent> = {
+const commonArgs: Partial<LocalizedTextGroupComponent<object>> = {
   size: 'lg',
   initialFocus: false,
   tooltip: 'Your city needs you!',
@@ -65,7 +65,7 @@ const ExampleAllRequiredTemplate: StoryFn = (args) => ({
     handleBlur: action('handleBlur'),
     handleViewInit: action('handleViewInit'),
     handleKeyUp: action('handleKeyUp'),
-    formGroup: new FormGroup<FudisLocalizedTextGroup<object>>({
+    formGroup: new FormGroup<FudisLocalizedTextGroupDefaultFormGroup>({
       fi: new FormControl<string | null>(null, [
         FudisValidators.required('Missing backstory in Finnish.'),
         FudisValidators.minLength(10, 'Too short backstory in Finnish'),
@@ -115,7 +115,7 @@ const ExampleTemplate: StoryFn = (args) => ({
       { controlName: 'sv', label: 'SV' },
       { controlName: 'en', label: 'EN' },
     ],
-    formGroup: new FormGroup<FudisLocalizedTextGroup<object>>(
+    formGroup: new FormGroup<FudisLocalizedTextGroupDefaultFormGroup>(
       {
         fi: new FormControl<string | null>(null, [
           FudisValidators.maxLength(15, 'Too long Finnish name'),

--- a/ngx-fudis/projects/ngx-fudis/src/lib/types/forms.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/types/forms.ts
@@ -51,14 +51,20 @@ export type FudisSelectOption<T extends object> = T & {
   [key: string]: unknown;
 };
 
-export type FudisLocalizedTextGroupOptions =
+export type FudisLocalizedTextGroupFormGroupOptions =
   | { controlName: 'fi'; label: 'FI' }
   | { controlName: 'sv'; label: 'SV' }
   | { controlName: 'en'; label: 'EN' }
   | { controlName: string; label: string };
 
-export type FudisLocalizedTextGroup<T extends object> = T & {
-  [lang: string | 'fi' | 'sv' | 'en']: FormControl<string | null>;
+export interface FudisLocalizedTextGroupDefaultFormGroup {
+  fi: FormControl<string | null>;
+  en: FormControl<string | null>;
+  sv: FormControl<string | null>;
+}
+
+export type FudisLocalizedTextGroupFormGroup<T> = {
+  [K in keyof T]: FormControl<string | null>;
 };
 
 export type FudisCheckboxGroupFormGroup<T> = {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/utilities/form/validator-utilities.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/utilities/form/validator-utilities.spec.ts
@@ -2,7 +2,10 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
 
 import { FudisValidators } from './validators';
 import { FudisValidatorUtilities } from './validator-utilities';
-import { FudisCheckboxGroupFormGroup, FudisLocalizedTextGroup } from '../../types/forms';
+import {
+  FudisCheckboxGroupFormGroup,
+  FudisLocalizedTextGroupDefaultFormGroup,
+} from '../../types/forms';
 import { FudisGroupValidators } from './groupValidators';
 
 describe('FudisValidatorUtilities functions', () => {
@@ -39,7 +42,7 @@ describe('FudisValidatorUtilities functions', () => {
     });
 
     it('should return true with oneRequired validator group with LocalizedTextGroup', () => {
-      const testFormGroup = new FormGroup<FudisLocalizedTextGroup<object>>(
+      const testFormGroup = new FormGroup<FudisLocalizedTextGroupDefaultFormGroup>(
         {
           fi: new FormControl<string | null>(null),
           sv: new FormControl<string | null>(''),


### PR DESCRIPTION
Jira ticket: https://funidata.atlassian.net/browse/DS-432

App developers requested this feature to enable stricker typing. Discussion found here: https://sisudev.slack.com/archives/C03G46K6LG1/p1733216094386739

Breaking change migration:
- Renamed `FudisLocalizedTextGroup` to `FudisLocalizedTextGroupFormGroup` to follow naming convetions
- Now LocalizedTextGroupComponent now requires one type parameter. In most cases application can use default type provided by Fudis (`FudisLocalizedTextGroupDefaultFormGroup`) or their own type.