### PR TITLE
[Dialog]: Add current dialogs length check

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/dialog/dialog.service.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/dialog/dialog.service.ts
@@ -35,7 +35,9 @@ export class FudisDialogService {
   public close(dialogResult?: any): void {
     const currentDialogs = this.ngMaterialDialog.openDialogs;
 
-    currentDialogs?.[currentDialogs.length - 1].close(dialogResult);
+    if (currentDialogs.length > 0) {
+      currentDialogs?.[currentDialogs.length - 1].close(dialogResult);
+    }
   }
 
   /**


### PR DESCRIPTION
Original ticket: https://funidata.atlassian.net/browse/OTM-33125
PR made for https://funidata.atlassian.net/browse/DS-421

- Added length check for MatDialog's `openDialogs`
- Apparently optional chaining was not sufficient and caused errors in application side