### PR TITLE
[SelectOption, MultiSelectOption]: Language change does not update the input value

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/mock_data.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/mock_data.ts
@@ -29,6 +29,19 @@ export const defaultOptions: FudisSelectOption<TestAnimalSound>[] = [
   { value: 'value-6-gecko', label: 'Southern Titiwangsa Bent-Toed Gecko', sound: 'Gec-koooo!' },
 ];
 
+export const defaultOptionsSecondaryLang: FudisSelectOption<TestAnimalSound>[] = [
+  { value: { name: 'Max The Great', breed: 'Staffy' }, label: 'Koira', sound: 'Hau!' },
+  { value: 'value-2-capybara', label: 'Kapybara', sound: 'Sviik!' },
+  { value: 'value-3-platypys', label: 'Vesinokkaeläin', sound: 'Läisk!' },
+  { value: 'value-4-cat', label: 'Erittäin vaarallinen kissa', disabled: true, sound: 'HurrRRuR!' },
+  {
+    value: 'value-5-armadillo_(PARTLY_ENDANGERED)',
+    label: 'Kirkuva karvainen armadillo (osittain uhanalainen)',
+    sound: "Klinks klanks klonks'!",
+  },
+  { value: 'value-6-gecko', label: 'Gekko', sound: 'Kukkuu!' },
+];
+
 export const multiselectChipListMockData: FudisSelectOption<object>[] = [
   { value: 'hereford', label: 'Hereford' },
   { value: 'texas-longhorn', label: 'Texas Longhorn' },

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-option-base/select-option-base.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-option-base/select-option-base.directive.ts
@@ -5,10 +5,7 @@ import { SelectComponent } from '../../select/select.component';
 import { SelectGroupComponent } from '../select-group/select-group.component';
 import { FudisSelectOption } from '../../../../../types/forms';
 import { MultiselectComponent } from '../../multiselect/multiselect.component';
-import { FudisTranslationService } from '../../../../../services/translation/translation.service';
 import { FudisIdService } from '../../../../../services/id/id.service';
-
-import { FudisLanguageAbbr } from '../../../../../types/miscellaneous';
 
 @Directive({
   selector: '[fudisSelectOptionBase]',
@@ -17,11 +14,9 @@ export class SelectOptionBaseDirective extends DropdownItemBaseDirective {
   constructor(
     @Inject(DOCUMENT) _document: Document,
     @Host() @Optional() protected _parentGroup: SelectGroupComponent,
-    protected _translationService: FudisTranslationService,
     protected _idService: FudisIdService,
   ) {
     super(_document);
-    this._appLanguage = _translationService.getLanguage();
   }
 
   /**
@@ -45,11 +40,6 @@ export class SelectOptionBaseDirective extends DropdownItemBaseDirective {
    * Focus state
    */
   protected _focused: boolean = false;
-
-  /**
-   * App language
-   */
-  protected _appLanguage: FudisLanguageAbbr;
 
   /**
    * Common parent and its properties for both Select and Multiselect

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-option-base/select-option-base.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-option-base/select-option-base.directive.ts
@@ -5,6 +5,7 @@ import { SelectComponent } from '../../select/select.component';
 import { SelectGroupComponent } from '../select-group/select-group.component';
 import { FudisSelectOption } from '../../../../../types/forms';
 import { MultiselectComponent } from '../../multiselect/multiselect.component';
+import { FudisTranslationService } from '../../../../../services/translation/translation.service';
 import { FudisIdService } from '../../../../../services/id/id.service';
 
 @Directive({
@@ -14,6 +15,7 @@ export class SelectOptionBaseDirective extends DropdownItemBaseDirective {
   constructor(
     @Inject(DOCUMENT) _document: Document,
     @Host() @Optional() protected _parentGroup: SelectGroupComponent,
+    protected _translationService: FudisTranslationService,
     protected _idService: FudisIdService,
   ) {
     super(_document);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect-option/multiselect-option.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect-option/multiselect-option.component.spec.ts
@@ -13,7 +13,7 @@ import { LabelComponent } from '../../../label/label.component';
 import { GuidanceComponent } from '../../../guidance/guidance.component';
 import { FudisSelectOption } from '../../../../../types/forms';
 import { getElement } from '../../../../../utilities/tests/utilities';
-import { defaultOptions } from '../../common/mock_data';
+import { defaultOptions, defaultOptionsSecondaryLang } from '../../common/mock_data';
 import { SelectIconsComponent } from '../../common/select-icons/select-icons.component';
 import { ButtonComponent } from '../../../../button/button.component';
 import { FudisInternalErrorSummaryService } from '../../../../../services/form/error-summary/internal-error-summary.service';
@@ -76,7 +76,6 @@ describe('MultiselectOptionComponent', () => {
 
     fixture = TestBed.createComponent(MultiselectMockComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   function setMultiSelectDropdownOpen() {
@@ -85,11 +84,14 @@ describe('MultiselectOptionComponent', () => {
   }
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
   describe('Options reflect on parent control value', () => {
     it('should have respective HTML attributes after parent control value changes', () => {
+      fixture.detectChanges();
+
       component.control.patchValue([defaultOptions[2]]);
       fixture.detectChanges();
 
@@ -104,7 +106,21 @@ describe('MultiselectOptionComponent', () => {
       expect(selectedOptionLabel).toEqual('Platypus');
     });
 
+    it('should change visible input value when options are changed', () => {
+      component.control.patchValue([defaultOptions[2]]);
+      fixture.detectChanges();
+
+      const element = getElement(fixture, '.fudis-select__input');
+      expect(element.getAttribute('value')).toEqual('Platypus');
+
+      component.multiOptions = defaultOptionsSecondaryLang;
+      fixture.detectChanges();
+      expect(element.getAttribute('value')).toEqual('Vesinokkaeläin');
+    });
+
     it('should add value to control with already existing values when another option is selected and emit selection', () => {
+      fixture.detectChanges();
+
       jest.spyOn(component.selectEl.selectionUpdate, 'emit');
 
       component.control.patchValue([defaultOptions[4], defaultOptions[0]]);
@@ -145,6 +161,8 @@ describe('MultiselectOptionComponent', () => {
     });
 
     it('should remove value from control when already selected option is clicked and set as null, if no selected options are left', () => {
+      fixture.detectChanges();
+
       setMultiSelectDropdownOpen();
 
       const options = fixture.debugElement.queryAll(By.css('fudis-multiselect-option'));
@@ -181,6 +199,10 @@ describe('MultiselectOptionComponent', () => {
   });
 
   describe('Single option HTML attributes', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
     it('should have respective attributes if selected', () => {
       setMultiSelectDropdownOpen();
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect-option/multiselect-option.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect-option/multiselect-option.component.ts
@@ -138,7 +138,7 @@ export class MultiselectOptionComponent
       if (
         this._parent.selectedOptionsFromLangChange.length === this._parent.control.value?.length
       ) {
-        this._parent._multiselectCVA.writeValue(this._parent.selectedOptionsFromLangChange);
+        this._parent._multiselectCVA?.writeValue(this._parent.selectedOptionsFromLangChange);
         this._parent.selectedOptionsFromLangChange = [];
       }
     }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect-option/multiselect-option.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect-option/multiselect-option.component.ts
@@ -6,6 +6,7 @@ import { SelectGroupComponent } from '../../common/select-group/select-group.com
 import { MultiselectComponent } from '../multiselect.component';
 import { SelectOptionBaseDirective } from '../../common/select-option-base/select-option-base.directive';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { FudisTranslationService } from '../../../../../services/translation/translation.service';
 import { FudisComponentChanges } from '../../../../../types/miscellaneous';
 
 @Component({
@@ -22,8 +23,9 @@ export class MultiselectOptionComponent
     @Host() protected _parentMultiselect: MultiselectComponent,
     @Host() @Optional() _parentGroup: SelectGroupComponent,
     _idService: FudisIdService,
+    _translationService: FudisTranslationService,
   ) {
-    super(_document, _parentGroup, _idService);
+    super(_document, _parentGroup, _translationService, _idService);
 
     this._parent = this._parentMultiselect;
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect-option/multiselect-option.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect-option/multiselect-option.component.ts
@@ -6,7 +6,6 @@ import { SelectGroupComponent } from '../../common/select-group/select-group.com
 import { MultiselectComponent } from '../multiselect.component';
 import { SelectOptionBaseDirective } from '../../common/select-option-base/select-option-base.directive';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { FudisTranslationService } from '../../../../../services/translation/translation.service';
 import { FudisComponentChanges } from '../../../../../types/miscellaneous';
 
 @Component({
@@ -23,9 +22,8 @@ export class MultiselectOptionComponent
     @Host() protected _parentMultiselect: MultiselectComponent,
     @Host() @Optional() _parentGroup: SelectGroupComponent,
     _idService: FudisIdService,
-    _translationService: FudisTranslationService,
   ) {
-    super(_document, _parentGroup, _translationService, _idService);
+    super(_document, _parentGroup, _idService);
 
     this._parent = this._parentMultiselect;
 
@@ -68,8 +66,8 @@ export class MultiselectOptionComponent
         this.checked = false;
       }
 
-      if (changes.data?.currentValue) {
-        this._onLangChangeCheckIfLabelRequiresUpdate(changes.data?.currentValue);
+      if (changes.data?.currentValue && changes.data.currentValue !== changes.data.previousValue) {
+        this._checkIfLabelRequiresUpdate(changes.data?.currentValue);
       }
     }
   }
@@ -123,28 +121,23 @@ export class MultiselectOptionComponent
   }
 
   /**
-   * When app language is changed, it will not change Form Control's value, which is intended, but
-   * visible label should be updated
+   * When option is changed, it will not change Form Control's value, which is intended, but visible
+   * label should be updated
    */
-  protected _onLangChangeCheckIfLabelRequiresUpdate(newData: FudisSelectOption<object>): void {
+  protected _checkIfLabelRequiresUpdate(newData: FudisSelectOption<object>): void {
     const controlValue = this._parent?.control.value;
+    const foundMatch = controlValue?.find((selectedOption) => {
+      return selectedOption.value === newData.value;
+    });
 
-    if (this._appLanguage !== this._translationService.getLanguage()) {
-      this._appLanguage = this._translationService.getLanguage();
+    if (foundMatch) {
+      this._parent.selectedOptionsFromLangChange.push(newData);
 
-      const foundMatch = controlValue?.find((selectedOption) => {
-        return selectedOption.value === newData.value;
-      });
-
-      if (foundMatch) {
-        this._parent.selectedOptionsFromLangChange.push(newData);
-
-        if (
-          this._parent.selectedOptionsFromLangChange.length === this._parent.control.value?.length
-        ) {
-          this._parent._multiselectCVA.writeValue(this._parent.selectedOptionsFromLangChange);
-          this._parent.selectedOptionsFromLangChange = [];
-        }
+      if (
+        this._parent.selectedOptionsFromLangChange.length === this._parent.control.value?.length
+      ) {
+        this._parent._multiselectCVA.writeValue(this._parent.selectedOptionsFromLangChange);
+        this._parent.selectedOptionsFromLangChange = [];
       }
     }
   }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/select/select-option/select-option.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/select/select-option/select-option.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SelectOptionComponent } from './select-option.component';
 import { SelectGroupComponent } from '../../common/select-group/select-group.component';
 import { SelectComponent } from '../select.component';
-import { defaultOptions } from '../../common/mock_data';
+import { defaultOptions, defaultOptionsSecondaryLang } from '../../common/mock_data';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Component, ViewChild } from '@angular/core';
 import { GuidanceComponent } from '../../../guidance/guidance.component';
@@ -150,6 +150,21 @@ describe('SelectOptionComponent', () => {
       expect(selectedValue.textContent).toEqual('Screaming hairy armadillo (partly endangered)');
 
       expect(checkIcon).toBeTruthy();
+    });
+
+    it('should change visible input value when options are changed', () => {
+      initializeFormControlWithValue();
+      setSelectDropdownOpen();
+
+      const selectElement = getElement(fixture, '.fudis-select');
+      let value = selectElement.querySelector('.fudis-select input')?.getAttribute('value');
+      expect(value).toEqual('Screaming hairy armadillo (partly endangered)');
+
+      component.testOptions = defaultOptionsSecondaryLang;
+      fixture.detectChanges();
+
+      value = selectElement.querySelector('.fudis-select input')?.getAttribute('value');
+      expect(value).toContain('Kirkuva karvainen armadillo (osittain uhanalainen)');
     });
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/select/select-option/select-option.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/select/select-option/select-option.component.ts
@@ -5,6 +5,7 @@ import { FudisIdService } from '../../../../../services/id/id.service';
 import { SelectComponent } from '../select.component';
 import { SelectGroupComponent } from '../../common/select-group/select-group.component';
 import { SelectOptionBaseDirective } from '../../common/select-option-base/select-option-base.directive';
+import { FudisTranslationService } from '../../../../../services/translation/translation.service';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FudisComponentChanges } from '../../../../../types/miscellaneous';
 import { FudisSelectOption } from '../../../../../types/forms';
@@ -22,9 +23,10 @@ export class SelectOptionComponent
     @Inject(DOCUMENT) _document: Document,
     @Host() protected _parentSelect: SelectComponent,
     @Host() @Optional() _parentGroup: SelectGroupComponent,
+    _translationService: FudisTranslationService,
     _idService: FudisIdService,
   ) {
-    super(_document, _parentGroup, _idService);
+    super(_document, _parentGroup, _translationService, _idService);
 
     this._parent = _parentSelect;
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/select/select-option/select-option.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/select/select-option/select-option.component.ts
@@ -5,7 +5,6 @@ import { FudisIdService } from '../../../../../services/id/id.service';
 import { SelectComponent } from '../select.component';
 import { SelectGroupComponent } from '../../common/select-group/select-group.component';
 import { SelectOptionBaseDirective } from '../../common/select-option-base/select-option-base.directive';
-import { FudisTranslationService } from '../../../../../services/translation/translation.service';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FudisComponentChanges } from '../../../../../types/miscellaneous';
 import { FudisSelectOption } from '../../../../../types/forms';
@@ -23,10 +22,9 @@ export class SelectOptionComponent
     @Inject(DOCUMENT) _document: Document,
     @Host() protected _parentSelect: SelectComponent,
     @Host() @Optional() _parentGroup: SelectGroupComponent,
-    _translationService: FudisTranslationService,
     _idService: FudisIdService,
   ) {
-    super(_document, _parentGroup, _translationService, _idService);
+    super(_document, _parentGroup, _idService);
 
     this._parent = _parentSelect;
 
@@ -56,9 +54,8 @@ export class SelectOptionComponent
       this._id = newOptionId;
 
       this._checkVisibilityFromFilterText(this._parent.getAutocompleteFilterText()());
-
-      if (changes.data?.currentValue) {
-        this._onLangChangeCheckIfLabelRequiresUpdate(changes.data.currentValue);
+      if (changes.data?.currentValue && changes.data.currentValue !== changes.data.previousValue) {
+        this._checkIfLabelRequiresUpdate(changes.data.currentValue);
       }
     }
   }
@@ -95,19 +92,14 @@ export class SelectOptionComponent
   }
 
   /**
-   * When app language is changed, it will not change Form Control's value, which is intended, but
-   * visible label should be updated
+   * When option is changed, it will not change Form Control's value, which is intended, but visible
+   * label should be updated
    */
-  protected _onLangChangeCheckIfLabelRequiresUpdate(newData: FudisSelectOption<object>): void {
+  protected _checkIfLabelRequiresUpdate(newData: FudisSelectOption<object>): void {
     const controlValue = this._parent?.control.value;
-
-    if (this._appLanguage !== this._translationService.getLanguage()) {
-      this._appLanguage = this._translationService.getLanguage();
-
-      if (controlValue?.value === newData.value) {
-        this._parent.selectCVA.writeValue(newData);
-        this._parent.setAutocompleteFilterText(newData.label, false);
-      }
+    if (controlValue?.value === newData.value) {
+      this._parent.selectCVA?.writeValue(newData);
+      this._parent.setAutocompleteFilterText(newData.label, false);
     }
   }
 


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-446

- Internal function renamed from `_onLangChangeCheckIfLabelRequiresUpdate` to `_checkIfLabelRequiresUpdate`.
- Removed internal variable `_appLanguage`
- Now select component's input value is always updated if `data` input is changed
