### PR TITLE
[Tooltip]: Accessibility fixes

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/tooltip/tooltip.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/tooltip/tooltip.directive.ts
@@ -60,7 +60,7 @@ export class TooltipDirective
   }
 
   /**
-   * When user's mouse enters to tooltip HTMLElement
+   * When user's mouse enters to tooltip's triggering HTMLElement
    */
   @HostListener('mouseenter') private _onMouseEnter() {
     if (!this.tooltipToggle && this._tooltipElement.nativeElement.hasAttribute('fudisTooltip')) {
@@ -69,7 +69,7 @@ export class TooltipDirective
   }
 
   /**
-   * When user's mouse leaves tooltip HTMLElement
+   * When user's mouse leaves either tooltip or tooltip's triggering HTMLElement
    */
   @HostListener('mouseleave', ['$event']) private _onMouseLeave(event: MouseEvent) {
     const targetElement = event?.relatedTarget as HTMLElement;
@@ -79,7 +79,7 @@ export class TooltipDirective
   }
 
   /**
-   * When tooltip HTMLElement receives focus
+   * When tooltip's triggering HTMLElement receives focus
    */
   @HostListener('focus') private _onFocus() {
     if (!this.tooltipToggle) {
@@ -88,7 +88,7 @@ export class TooltipDirective
   }
 
   /**
-   * When tooltip HTMLElement is blurred out
+   * When tooltip's triggering HTMLElement is blurred out
    */
   @HostListener('blur') private _onBlur() {
     if (!this.preventBlur) this._ngMaterialTooltip.hide();
@@ -96,7 +96,7 @@ export class TooltipDirective
   }
 
   /**
-   * When user clicks tooltip HTMLElement
+   * When user clicks tooltip's triggering HTMLElement
    */
   @HostListener('click') private _onClick() {
     if (this.tooltipToggle && this._tooltipElement.nativeElement.hasAttribute('fudisTooltip')) {
@@ -105,17 +105,11 @@ export class TooltipDirective
   }
 
   /**
-   * When key is pressed on tooltip HTMLElement
+   * When key is pressed on tooltip's triggering HTMLElement
    */
   @HostListener('keyup', ['$event']) private _onKeyUp(event: KeyboardEvent) {
-    if (
-      this.tooltipToggle &&
-      (event.key === 'Enter' || event.key === ' ') &&
-      this._tooltipElement.nativeElement.hasAttribute('fudisTooltip') &&
-      !this.tooltipToggle
-    ) {
-      event.preventDefault();
-      this._toggleTooltip();
+    if (event.key === 'Escape') {
+      this._ngMaterialTooltip.hide();
     }
   }
 
@@ -144,6 +138,9 @@ export class TooltipDirective
     );
   }
 
+  /**
+   * Toggle tooltip visibility
+   */
   private _toggleTooltip = () => {
     if (!this._ngMaterialTooltip._isTooltipVisible()) {
       this._showTooltip();
@@ -152,6 +149,9 @@ export class TooltipDirective
     }
   };
 
+  /**
+   * Helper to detect hover on tooltip element
+   */
   private _targetOnToolTip(element: HTMLElement) {
     return element?.classList?.contains('mdc-tooltip');
   }
@@ -165,6 +165,9 @@ export class TooltipDirective
     }
   }
 
+  /**
+   * Helper for preventing blur when interacting with text content inside tooltip
+   */
   private _createTooltipEventListener() {
     this.preventBlur = true;
   }

--- a/test/visual-regression/tooltip.spec.ts
+++ b/test/visual-regression/tooltip.spec.ts
@@ -21,6 +21,18 @@ test("tooltip toggle", async ({ page }) => {
 
   await page.mouse.click(0, 0); // Click away from the tooltip
   await expect(page.locator("mat-tooltip-component")).not.toBeVisible();
+
+  await page.getByTestId("fudis-button-1").click();
+  await expect(page.locator("mat-tooltip-component")).toBeVisible();
+  await page.keyboard.press("Escape"); // Dismiss tooltip with Esc
+  await expect(page.locator("mat-tooltip-component")).not.toBeVisible();
+
+  await page.getByTestId("fudis-button-1").focus();
+  await expect(page.locator("mat-tooltip-component")).not.toBeVisible();
+  await page.getByTestId("fudis-button-1").click();
+  await expect(page.locator("mat-tooltip-component")).toBeVisible();
+  await page.getByTestId("fudis-button-1").blur(); // Dismiss tooltip by blurring away
+  await expect(page.locator("mat-tooltip-component")).not.toBeVisible();
 });
 
 test("tooltip hover", async ({ page }) => {

--- a/test/visual-regression/tooltip.spec.ts
+++ b/test/visual-regression/tooltip.spec.ts
@@ -4,10 +4,42 @@ test("tooltip toggle", async ({ page }) => {
   await page.goto(
     "/iframe.html?args=tooltipToggle:!true&id=directives-tooltip--example-with-fudis-button&viewMode=story",
   );
+
   await page.getByTestId("fudis-button-1").click();
   await page.waitForTimeout(150).then(async () => {
     await expect(page).toHaveScreenshot("toggle.png");
   });
+
+  const tooltipText = await page.locator(".mdc-tooltip .mdc-tooltip__surface").textContent();
+
+  await page.getByTestId("cdk-overlay-0").click(); // Click tooltip overlay element
+  await expect(page.locator("mat-tooltip-component")).toBeVisible();
+  await expect(tooltipText).toBe("Greetings from tooltip, I hope you can see me!");
+
+  await page.mouse.move(0, 0); // Move mouse away from the tooltip
+  await expect(page.locator("mat-tooltip-component")).toBeVisible();
+
+  await page.mouse.click(0, 0); // Click away from the tooltip
+  await expect(page.locator("mat-tooltip-component")).not.toBeVisible();
+});
+
+test("tooltip hover", async ({ page }) => {
+  await page.goto(
+    "/iframe.html?globals=&id=directives-tooltip--example-with-fudis-button&viewMode=story",
+  );
+
+  await expect(page.locator("mat-tooltip-component")).not.toBeVisible();
+  await page.getByTestId("fudis-button-1").hover();
+  await expect(page.locator("mat-tooltip-component")).toBeVisible();
+
+  const tooltipText = await page.locator(".mdc-tooltip .mdc-tooltip__surface").textContent();
+
+  await page.getByTestId("cdk-overlay-0").click(); // Click tooltip overlay element
+  await expect(page.locator("mat-tooltip-component")).toBeVisible();
+  await expect(tooltipText).toBe("Greetings from tooltip, I hope you can see me!");
+
+  await page.mouse.move(0, 0); // Move mouse away from the tooltip
+  await expect(page.locator("mat-tooltip-component")).not.toBeVisible();
 });
 
 test("tooltip should be hidden when scrolled out of view", async ({ page }) => {


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-340

- Enable possibility to interact with tooltip content:
   - Hover over the tooltip without it disappearing
   - Copying text inside the tooltip
- Enable closing tooltip with `Esc`
- Add E2E tests (most of the functionality is tested here, instead of unit tests)


_Note:_ Known issue/feature coming from [ngMaterial Tooltip](https://material.angular.io/components/tooltip/overview) is that even though our own `tooltipToggle` is set to `true`, the tooltip element will disappear always after mouse leaves the `<mat-tooltip-component>`. This issue will be fixed when creating our own Popover Component without ngMaterial dependency.