### PR TITLE
[Breadcrumbs, Grid]: Add and clean up tests

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/breadcrumbs/breadcrumbs.component.spec.ts
@@ -6,7 +6,6 @@ import { IconComponent } from '../icon/icon.component';
 import { BodyTextComponent } from '../typography/body-text/body-text.component';
 import { BreadcrumbsItemComponent } from './breadcrumbs-item/breadcrumbs-item.component';
 import { RouterModule } from '@angular/router';
-import { LinkDirective } from '../../directives/link/link.directive';
 import { getElement } from '../../utilities/tests/utilities';
 
 @Component({
@@ -28,14 +27,13 @@ class MockComponent {
 }
 
 describe('BreadcrumbsComponent', () => {
-  let fixture: ComponentFixture<BreadcrumbsComponent> | ComponentFixture<MockComponent>;
+  let fixture: ComponentFixture<MockComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
+    TestBed.configureTestingModule({
       declarations: [
         BreadcrumbsComponent,
         BreadcrumbsItemComponent,
-        LinkDirective,
         IconComponent,
         BodyTextComponent,
         MockComponent,
@@ -44,8 +42,7 @@ describe('BreadcrumbsComponent', () => {
     });
 
     fixture = TestBed.createComponent(MockComponent);
-
-    fixture.autoDetectChanges();
+    fixture.detectChanges();
   });
 
   it('should render the correct number of breadcrumb items', () => {
@@ -75,7 +72,7 @@ describe('BreadcrumbsComponent', () => {
       const linkHrefs: (string | null | undefined)[] = [];
 
       items.forEach((item) => {
-        const linkElement: Element | null = (item as Element)!.querySelector(
+        const linkElement: HTMLAnchorElement | null = (item as HTMLAnchorElement)!.querySelector(
           '.fudis-breadcrumbs-item a',
         );
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/breadcrumbs/breadcrumbs.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/breadcrumbs/breadcrumbs.component.ts
@@ -3,7 +3,6 @@ import {
   Input,
   ViewEncapsulation,
   ChangeDetectionStrategy,
-  effect,
 } from '@angular/core';
 import { FudisTranslationService } from '../../services/translation/translation.service';
 import { FudisIdService } from '../../services/id/id.service';
@@ -22,10 +21,7 @@ export class BreadcrumbsComponent {
     private _idService: FudisIdService,
   ) {
     this._id = this._idService.getNewParentId('breadcrumbs');
-
-    effect(() => {
-      this._breadcrumbsPrefix.next(this._translationService.getTranslations()().BREADCRUMBS.PREFIX);
-    });
+    this._breadcrumbsPrefix.next(this._translationService.getTranslations()().BREADCRUMBS.PREFIX);
   }
 
   /**

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/breadcrumbs/readme.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/breadcrumbs/readme.mdx
@@ -16,7 +16,7 @@ Breadcrumbs organism is built using parent wrapper of Breadcrumbs Component and 
 
 ### Breadcrumbs - Parent Component
 
-Necessary properties for Breadcrumbs Component is `label`.
+Necessary property for Breadcrumbs Component is `label`.
 
 `label` is used as aria-label and it should describe the name of the section breadcrumbs consists from, e.g. _"My profile"_. Aria-label will automatically have a prefix _"Breadcrumbs: "_ which will be followed by the given label.
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid-item/grid-item.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid-item/grid-item.component.spec.ts
@@ -1,37 +1,26 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
-import { MockComponent } from 'ng-mocks';
 import { By } from '@angular/platform-browser';
 import { GridItemComponent } from './grid-item.component';
-import { FudisBreakpointService } from '../../../services/breakpoint/breakpoint.service';
-import { FudisBreakpointStyleResponsive } from '../../../types/breakpoints';
-import { FudisGridItemAlignment } from '../../../types/grid';
 import { GridComponent } from '../grid/grid.component';
-import { HeadingComponent } from '../../typography/heading/heading.component';
 import { BodyTextComponent } from '../../typography/body-text/body-text.component';
-import { ButtonComponent } from '../../button/button.component';
+import { FudisBreakpointService } from '../../../services/breakpoint/breakpoint.service';
+
+// NOTE: As most of this component's functionality is visual and it adds inline style properties, testing these with Jest is not feasible.
+// Visual Regression tests (grid-item.spec.ts) should be sufficient to cover testing these.
 
 @Component({
   selector: 'fudis-mock-grid-item-component',
   template: `<fudis-grid [columns]="6">
-    <fudis-heading [level]="2">I am test heading</fudis-heading>
-    <fudis-grid-item [columns]="columns">
-      <fudis-body-text>
-        Paragraph text for testing grid item functionalities. This is so much fun!
-      </fudis-body-text>
+    <fudis-grid-item [columns]="1">
+      <fudis-body-text> Paragraph text for testing grid item existance. </fudis-body-text>
     </fudis-grid-item>
-    <fudis-grid-item [alignSelfY]="alignSelfY" [alignSelfX]="alignSelfX">
-      <fudis-button [label]="'Test button'" />
+    <fudis-grid-item [alignSelfY]="'stretch'" [alignSelfX]="'stretch'">
+      <fudis-body-text> Paragraph text for testing grid item existance. </fudis-body-text>
     </fudis-grid-item>
   </fudis-grid>`,
 })
-class HostComponent {
-  columns: string | FudisBreakpointStyleResponsive = '1';
-
-  alignSelfX: FudisGridItemAlignment = 'stretch';
-
-  alignSelfY: FudisGridItemAlignment = 'stretch';
-}
+class HostComponent {}
 
 describe('GridItemComponent', () => {
   let component: HostComponent;
@@ -43,9 +32,7 @@ describe('GridItemComponent', () => {
         HostComponent,
         GridItemComponent,
         GridComponent,
-        MockComponent(HeadingComponent),
-        MockComponent(BodyTextComponent),
-        MockComponent(ButtonComponent),
+        BodyTextComponent,
       ],
       providers: [FudisBreakpointService],
     }).compileComponents();
@@ -69,6 +56,4 @@ describe('GridItemComponent', () => {
       expect(getGridItemComponent().length).toBe(2);
     });
   });
-
-  // NOTE: as most of components functionality is visual and it adds inline style properties testing these with Jest is not feasible. Visual Regression tests should be sufficient to cover testing these.
 });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid/grid.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid/grid.component.spec.ts
@@ -2,6 +2,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { GridComponent } from './grid.component';
 import { FudisBreakpointService } from '../../../services/breakpoint/breakpoint.service';
 
+// NOTE: As most of this component's functionality is visual and it adds inline style properties, testing these with Jest is not feasible.
+// Visual Regression tests (grid.spec.ts) should be sufficient to cover testing these.
+
 describe('GridComponent', () => {
   let component: GridComponent;
   let fixture: ComponentFixture<GridComponent>;
@@ -16,7 +19,6 @@ describe('GridComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(GridComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/grid/grid-utils.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/grid/grid-utils.spec.ts
@@ -1,7 +1,10 @@
-import { FudisGridProperties } from '../../types/grid';
+import {
+  FudisDefaultGridProperties,
+  fudisGridAlignItemsArray,
+  FudisGridProperties,
+  FudisGridPropertyCollection,
+} from '../../types/grid';
 import * as utils from './gridUtils';
-
-// TODO: Add tests for replaceFormInputWidthsToRem, getGridInputPropertyObject functions. Check if other tests are missing.
 
 describe('GridUtils', () => {
   describe('getGridCssValue function', () => {
@@ -28,6 +31,13 @@ describe('GridUtils', () => {
 
       expect(correctReturnString).toBe('1/-1');
 
+      fudisGridAlignItemsArray.forEach((value) => {
+        isGridItem = false;
+        correctReturnString = utils.getGridCssValue(value, isGridItem);
+
+        expect(correctReturnString).toBe(value);
+      });
+
       value = 'inputXs';
       correctReturnString = utils.getGridCssValue(value);
 
@@ -47,6 +57,27 @@ describe('GridUtils', () => {
       correctReturnString = utils.getGridCssValue(value);
 
       expect(correctReturnString).toBe('calc(23rem / var(--fudis-rem-multiplier))');
+    });
+  });
+
+  describe('replaceFormInputWidthsToRem function', () => {
+    it('should return corresponding string with rem calculation', () => {
+      let values: string;
+      let returnValue: string;
+
+      values = 'inputXs inputSm';
+      returnValue = utils.replaceFormInputWidthsToRem(values);
+
+      expect(returnValue).toBe(
+        'calc(4rem / var(--fudis-rem-multiplier)) calc(10rem / var(--fudis-rem-multiplier))',
+      );
+
+      values = 'inputMd inputLg';
+      returnValue = utils.replaceFormInputWidthsToRem(values);
+
+      expect(returnValue).toBe(
+        'calc(14rem / var(--fudis-rem-multiplier)) calc(23rem / var(--fudis-rem-multiplier))',
+      );
     });
   });
 
@@ -76,6 +107,87 @@ describe('GridUtils', () => {
       expect(utils.getGridClasses(values)).toBe(
         'fudis-grid fudis-grid__xxl fudis-grid__align__end my-custom-class my-other-custom-class',
       );
+    });
+  });
+
+  describe('getValuesForCSSClasses', () => {
+    it('should return correct values depending on defualt settings', () => {
+      let properties: FudisGridPropertyCollection;
+      let serviceDefaults: boolean;
+      let returnObject: FudisGridProperties;
+
+      const emptyAppValues = {};
+      const emptyServiceValues = {};
+      
+      const valuesFromDefaults: FudisDefaultGridProperties = {
+        align: 'center',
+        alignItemsY: 'center',
+        alignItemsX: 'center',
+        classes: 'default-test-class',
+        columnGap: 'none',
+        rowGap: 'none',
+        width: 'xxl',
+      };
+
+      const valuesFromApp: FudisGridProperties = {
+        align: 'start',
+        alignItemsY: 'start',
+        alignItemsX: 'start',
+        classes: 'app-test-class',
+        columnGap: 'md',
+        rowGap: 'sm',
+        width: 'lg',
+      };
+
+      const valuesFromService: FudisDefaultGridProperties = {
+        align: 'center',
+        alignItemsY: 'start',
+        alignItemsX: 'start',
+        classes: 'service-test-class',
+        columnGap: 'lg',
+        rowGap: 'md',
+        width: 'md',
+      };
+
+      // Returns appValues
+      properties = {
+        appValues: valuesFromApp,
+        defaultValues: valuesFromDefaults,
+        serviceValues: valuesFromService,
+      };
+      serviceDefaults = false;
+      returnObject = utils.getValuesForCSSClasses(properties, serviceDefaults);
+      expect(returnObject).toStrictEqual(valuesFromApp);
+
+      // Returns defaultValues
+      properties = {
+        appValues: emptyAppValues,
+        defaultValues: valuesFromDefaults,
+        serviceValues: valuesFromService,
+      };
+      serviceDefaults = false;
+      returnObject = utils.getValuesForCSSClasses(properties, serviceDefaults);
+      expect(returnObject).toStrictEqual(valuesFromDefaults);
+
+      // Returns serviceValues
+      properties = {
+        appValues: emptyAppValues,
+        defaultValues: valuesFromDefaults,
+        serviceValues: valuesFromService,
+      };
+      serviceDefaults = true;
+      returnObject = utils.getValuesForCSSClasses(properties, serviceDefaults);
+      expect(returnObject).toStrictEqual(valuesFromService);
+
+      // Returns defaultValues
+      properties = {
+        appValues: emptyAppValues,
+        defaultValues: valuesFromDefaults,
+        serviceValues: emptyServiceValues,
+      };
+      serviceDefaults = true;
+      returnObject = utils.getValuesForCSSClasses(properties, serviceDefaults);
+      expect(returnObject).toStrictEqual(valuesFromDefaults);
     });
   });
 });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/types/grid.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/types/grid.ts
@@ -41,7 +41,8 @@ export type FudisGridAlign = 'start' | 'end' | 'center';
 /**
  * Alignment of Grid Items inside a Grid
  */
-export type FudisGridAlignItems = 'start' | 'center' | 'end' | 'stretch';
+export const fudisGridAlignItemsArray = ['start', 'center', 'end', 'stretch'] as const;
+export type FudisGridAlignItems = (typeof fudisGridAlignItemsArray)[number];
 
 /**
  * Spacing between columns and rows inside Grid


### PR DESCRIPTION
- Removed unnecessary effect in Breadcrumbs Component, there were no signals used
- Existing VR tests for Grid and Grid Item were sufficient, these components don't need unit test since their main functionality is not feasible to test in Jest.
- Added missing unit tests for Grid Utils