### PR TITLE
[Tooltip Directive]: DEPRECATION flag

### DIFF
--- a/ngx-fudis/.storybook/main.js
+++ b/ngx-fudis/.storybook/main.js
@@ -27,7 +27,6 @@ export const staticDirs = [
 ];
 export const docs = {
   defaultName: "Documentation",
-  autodocs: true,
 };
 
 export function managerHead(head) {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/tooltip/tooltip.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/tooltip/tooltip.directive.ts
@@ -13,6 +13,9 @@ import { TooltipApiDirective } from './tooltip-api.directive';
 import { ScrollDispatcher } from '@angular/cdk/overlay';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
+/**
+ * @deprecated since 5.0. Tooltip directive will be removed in Fudis version 7.0. Use Fudis Popover Directive instead.
+ */
 @Directive({
   selector: '[fudisTooltip]',
   exportAs: 'tooltip',

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/tooltip/tooltip.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/tooltip/tooltip.directive.ts
@@ -14,7 +14,8 @@ import { ScrollDispatcher } from '@angular/cdk/overlay';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 /**
- * @deprecated since 5.0. Tooltip directive will be removed in Fudis version 7.0. Use Fudis Popover Directive instead.
+ * @deprecated Since 5.0. Tooltip directive will be removed in Fudis version 7.0. Use Fudis Popover
+ *   Directive instead.
  */
 @Directive({
   selector: '[fudisTooltip]',

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/tooltip/tooltip.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/tooltip/tooltip.mdx
@@ -6,6 +6,7 @@ import { tooltipExclude } from "../../utilities/storybook.ts";
 <Meta title="Directives/Tooltip" />
 
 # Tooltip Directive - DEPRECATED
+
 > **Directive has been deprecated since Fudis version 5.0 and it will be further removed in version 7.0.** It is recommended to start using [Popover Directive](/docs/directives-popover--documentation) instead.
 
 Tooltip shows contextual help or information about specific element when user hovers, focuses or clicks on it, depending on the given properties.

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/tooltip/tooltip.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/tooltip/tooltip.mdx
@@ -5,7 +5,8 @@ import { tooltipExclude } from "../../utilities/storybook.ts";
 
 <Meta title="Directives/Tooltip" />
 
-# Tooltip Directive
+# Tooltip Directive - DEPRECATED
+> **Directive has been deprecated since Fudis version 5.0 and it will be further removed in version 7.0.** It is recommended to start using [Popover Directive](/docs/directives-popover--documentation) instead.
 
 Tooltip shows contextual help or information about specific element when user hovers, focuses or clicks on it, depending on the given properties.
 Fudis Tooltip directive uses Angular Material Tooltip as its base.


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-451

Added deprecation flag to Tooltip Directive. Documented the decision of directive removal on major version 7.0. Also removed autoDocs: true from storybook main.js, which was included in Storybook upgrade. Felt that is was redundant.

Note: Wasn't sure if this is a chore.