### PR TITLE
[RadioButtonGroup, CheckboxGroup]: Missing aria-describedby value

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox-group/checkbox-group.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox-group/checkbox-group.component.html
@@ -17,9 +17,10 @@
     <ng-content select="fudis-checkbox" />
     <fudis-guidance
       *ngIf="formGroup && !disableGuidance"
+      [id]="id + '_guidance'"
+      [for]="id + '-legend'"
       [inputLabel]="label"
       [helpText]="helpText"
-      [for]="id + '-legend'"
       [groupBlurredOut]="groupBlurredOut"
       [formGroup]="formGroup"
     >

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox-group/checkbox-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox-group/checkbox-group.component.spec.ts
@@ -16,6 +16,7 @@ import { IconComponent } from '../../icon/icon.component';
 import { GuidanceComponent } from '../guidance/guidance.component';
 import { ValidatorErrorMessageComponent } from '../error-message/validator-error-message/validator-error-message.component';
 import { FudisInternalErrorSummaryService } from '../../../services/form/error-summary/internal-error-summary.service';
+import { getElement } from '../../../utilities/tests/utilities';
 
 type TestForm = {
   apple: FormControl<boolean | null>;
@@ -204,10 +205,11 @@ describe('CheckboxGroupComponent', () => {
       expect(fieldsetElement.getAttribute('id')).toEqual('fudis-checkbox-group-1');
     });
 
-    it('should have correct aria-describedby value', () => {
-      expect(fieldsetElement.getAttribute('aria-describedby')).toEqual(
-        'fudis-checkbox-group-1_guidance',
-      );
+    it('should have correct aria-describedby value passed for guidance', () => {
+      const fieldsetAriaDescribedBy = fieldsetElement.getAttribute('aria-describedby');
+      const guidance = getElement(fixture, 'fudis-guidance');
+
+      expect(guidance.getAttribute('id')).toEqual(fieldsetAriaDescribedBy);
     });
   });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox-group/checkbox-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox-group/checkbox-group.component.spec.ts
@@ -177,6 +177,19 @@ describe('CheckboxGroupComponent', () => {
       expect(helpText.textContent).toContain('Some help text');
     });
 
+    it('should have correct helptext and aria hidden set to false in the legend', () => {
+      const helpText = fixture.nativeElement.querySelector(
+        '.fudis-guidance__help-text',
+      ) as HTMLElement;
+
+      const groupHelpText = fixture.nativeElement.querySelector(
+        '.fudis-fieldset__legend__main__group-helptext',
+      ) as HTMLElement;
+
+      expect(groupHelpText.getAttribute('aria-hidden')).toEqual('false');
+      expect(groupHelpText.textContent).toEqual(helpText.textContent);
+    });
+
     it('should display required text', () => {
       const requiredText = fixture.nativeElement.querySelector(
         '.fudis-fieldset__legend__main__required',

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox-group/checkbox-group.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/checkbox-group/checkbox-group.mdx
@@ -187,7 +187,7 @@ Popover can be included in the checkbox group fieldset with properties from [Pop
 - Fieldset has a legend as its first child element
 - When selection is mandatory, it is communicated with 'Required' text using validators
 - Checkbox options are grouped by name attribute
-- Guidance is linked to the Checkbox Group's fieldset element via aria-describedby
+- Guidance help text has been added to the Checkbox Group's legend element and made accessible to screen readers
 - Possible error messages are displayed after user blurs out from the whole checkbox group
 
 ## Properties of Checkbox Group Component

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/fieldset/fieldset.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/fieldset/fieldset.component.html
@@ -27,6 +27,10 @@
           ><span *ngIf="required" class="fudis-fieldset__legend__main__required"
             >({{ _translationService.getTranslations()().REQUIRED }})</span
           >
+          <div
+            aria-hidden="true"
+            class="fudis-fieldset__legend__main__group-helptext fudis-visually-hidden"
+          ></div>
         </div>
         <fudis-button
           *ngIf="popoverText && popoverTriggerLabel"
@@ -41,7 +45,7 @@
         />
       </div>
     </legend>
-    <fudis-body-text class="fudis-fieldset__help-text" *ngIf="helpText" [variant]="'sm-regular'">{{
+    <fudis-body-text *ngIf="helpText" class="fudis-fieldset__help-text" [variant]="'sm-regular'">{{
       helpText
     }}</fudis-body-text>
     <ng-content select="fudis-fieldset-actions"></ng-content>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/fieldset/fieldset.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/fieldset/fieldset.component.spec.ts
@@ -128,6 +128,15 @@ describe('FieldSetComponent', () => {
       expect(fieldsetHelpText?.textContent).toEqual('Fieldset help text');
     });
 
+    it('should have aria hidden true as default for group help text', () => {
+      const requiredTextElement = getElement(
+        fixtureMock,
+        '.fudis-fieldset__legend__main__group-helptext',
+      );
+
+      expect(requiredTextElement.getAttribute('aria-hidden')).toEqual('true');
+    });
+
     it('should have required text if given', () => {
       componentMock.required = true;
       fixtureMock.detectChanges();

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/fieldset/fieldset.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/fieldset/fieldset.component.ts
@@ -135,6 +135,11 @@ export class FieldSetComponent
    */
   private _fieldsetSent: boolean = false;
 
+  /**
+   * Private reference to Guidance
+   */
+  private _fieldsetGuidance: HTMLElement;
+
   private _parentFormId: string | null;
 
   /**
@@ -157,6 +162,9 @@ export class FieldSetComponent
           this._addToErrorSummary(this.label);
         }
       });
+    this._fieldsetGuidance = this._element.nativeElement.querySelector(
+      'fudis-guidance',
+    ) as HTMLElement;
   }
 
   ngAfterViewInit(): void {
@@ -182,6 +190,7 @@ export class FieldSetComponent
 
       this._resizeObserver.observe(this._fieldsetLegend.nativeElement);
     }
+    this._hasSelectionGroupParent();
   }
 
   ngOnChanges(changes: FudisComponentChanges<FieldSetComponent>): void {
@@ -218,6 +227,32 @@ export class FieldSetComponent
       if (elementHasLinkClass) {
         this._legendFocusVisible = true;
         this._fieldsetLegend.nativeElement.focus();
+      }
+    }
+  }
+
+  /**
+   * Determines if Fieldset has CheckboxGroup or RadioButtonGroup as a parent. If so, adds Guidance
+   * helptext as part of the Fieldset legend element and makes it accessible for screen readers.
+   */
+  private _hasSelectionGroupParent(): void {
+    const isParentGroup = ['fudis-radio-button-group', 'fudis-checkbox-group'].some((id) =>
+      this.id.includes(id),
+    );
+
+    if (isParentGroup) {
+      const groupHelpText = this._element.nativeElement.querySelector(
+        '.fudis-fieldset__legend__main__group-helptext',
+      ) as HTMLElement;
+      const guidanceHelpText = this._fieldsetGuidance.querySelector(
+        '.fudis-guidance__help-text',
+      )?.textContent;
+
+      if (guidanceHelpText) {
+        groupHelpText.setAttribute('aria-hidden', 'false');
+
+        const helptext = groupHelpText.appendChild(document.createElement('span'));
+        helptext.textContent = guidanceHelpText ?? '';
       }
     }
   }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.html
@@ -17,9 +17,10 @@
     <ng-content select="fudis-radio-button" />
     <fudis-guidance
       *ngIf="control && !disableGuidance"
+      [id]="id + '_guidance'"
+      [for]="id + '-legend'"
       [inputLabel]="label"
       [helpText]="helpText"
-      [for]="id + '-legend'"
       [control]="control"
     >
       <ng-content select="fudis-error-message" />

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.spec.ts
@@ -143,10 +143,11 @@ describe('Basic inputs of Radio Button Group', () => {
     expect(fieldsetElement.getAttribute('id')).toEqual('fudis-radio-button-group-1');
   });
 
-  it('should have correct aria-describedby value', () => {
-    expect(fieldsetElement.getAttribute('aria-describedby')).toEqual(
-      'fudis-radio-button-group-1_guidance',
-    );
+  it('should have correct aria-describedby value passed for guidance', () => {
+    const fieldsetAriaDescribedBy = fieldsetElement.getAttribute('aria-describedby');
+    const guidance = getElement(fixture, 'fudis-guidance');
+
+    expect(guidance.getAttribute('id')).toEqual(fieldsetAriaDescribedBy);
   });
 
   describe('Child Radio Buttons', () => {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.spec.ts
@@ -115,6 +115,19 @@ describe('Basic inputs of Radio Button Group', () => {
     expect(helpText.textContent).toContain('Some help text');
   });
 
+  it('should have correct helptext and aria hidden set to false in the legend', () => {
+    const helpText = fixture.nativeElement.querySelector(
+      '.fudis-guidance__help-text',
+    ) as HTMLElement;
+
+    const groupHelpText = fixture.nativeElement.querySelector(
+      '.fudis-fieldset__legend__main__group-helptext',
+    ) as HTMLElement;
+
+    expect(groupHelpText.getAttribute('aria-hidden')).toEqual('false');
+    expect(groupHelpText.textContent).toEqual(helpText.textContent);
+  });
+
   it('should display required text', () => {
     const requiredText = fixture.nativeElement.querySelector(
       '.fudis-fieldset__legend__main__required',

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.mdx
@@ -75,7 +75,7 @@ When clicking any of the child Radio Buttons, the parent's property `handleChang
 - Fieldset has a legend as its first child element
 - When selection is mandatory, it is communicated with 'Required' text using validators
 - Radio Button options are grouped by name attribute
-- Guidance is linked to the Radio Button Group's fieldset element via aria-describedby
+- Guidance help text has been added to the Radio Button Group's legend element and made accessible to screen readers
 - Possible error messages are displayed after user blurs out from the first Radio Button option
 
 ## Properties of Radio Button Group Component

--- a/ngx-fudis/projects/ngx-fudis/src/lib/foundations/utilities/mixins.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/foundations/utilities/mixins.scss
@@ -8,7 +8,6 @@
 
 @mixin visually-hidden() {
   position: absolute;
-  left: 0;
   opacity: 0;
   margin: -1px;
   outline: 0;


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-459

Reported issue existed only with Voice Over and Chrome/Firefox combination. 
Voice Over and Safari worked as expected. Note! This should be tested with NVDA and browser combination as well.

After changes VoiceOver behaviour with Chrome:
- Group on focus, press "control+option+command+/“ for additional information.

After changes VoiceOver behaviour with Firefox:
- Reads guidance's additional information immediately **at the end of group**.

Edited RadioButtonGroup and CheckboxGroup unit tests to check that guidance id and fieldset aria-describedby attribute match.