### PR TITLE
[TextArea, TextInput, Label]: Update tests and fix aria-invalid visibility

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.ts
@@ -174,7 +174,6 @@ export class GuidanceComponent implements OnChanges, OnInit, AfterContentInit, A
       injector: this._injector,
     }).subscribe((errors) => {
       let errorsFound = !!errors?.[this.for];
-
       // With FormGroups errors are defined differently, so this checks if FormGroups control has errors
       if (this.formGroup && !errorsFound) {
         errorsFound = Object.keys(this.formGroup.controls).some((controlName) => {
@@ -237,6 +236,14 @@ export class GuidanceComponent implements OnChanges, OnInit, AfterContentInit, A
       }
 
       if (numberOfErrors === this._lazyLoadedErrors.length && !this._reloadGuard) {
+        /**
+         * TODO: This needs to be though again. Currently this function happens before
+         * _subscribeToErrors, so the on push components are not reacting to the changes to the
+         * controls when they are marked as touched. This is a quick fix to that, but a ticket shall
+         * be made.
+         */
+        if (this.formGroup) this.formGroup.markAllAsTouched();
+        if (this.control) this.control.markAsTouched();
         this._errorSummaryService.reloadFormErrors(this._parentFormId()!, false);
       }
     }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/label/label.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/label/label.component.html
@@ -14,7 +14,6 @@
     [icon]="'info-circle'"
     [labelHidden]="true"
     [label]="popoverTriggerLabel"
-    [ariaLabel]="popoverTriggerLabel"
     [popoverText]="popoverText"
     [popoverPosition]="popoverPosition"
   />

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/label/label.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/label/label.component.spec.ts
@@ -48,11 +48,9 @@ describe('LabelComponent', () => {
       fixture.componentRef.setInput('popoverText', 'I am the info');
       fixture.componentRef.setInput('popoverTriggerLabel', 'This gives more info');
       fixture.detectChanges();
-      const tooltipTriggerElem = getElement(fixture, 'fudis-button');
+      const tooltipTriggerElem = getElement(fixture, 'button');
       expect(tooltipTriggerElem).toBeTruthy();
-      expect(tooltipTriggerElem.getAttribute('ng-reflect-aria-label')).toEqual(
-        'This gives more info',
-      );
+      expect(tooltipTriggerElem.getAttribute('aria-label')).toEqual('This gives more info');
       expect(tooltipTriggerElem.getAttribute('ng-reflect-popover-text')).toEqual('I am the info');
     });
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/label/label.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/label/label.component.spec.ts
@@ -56,6 +56,14 @@ describe('LabelComponent', () => {
       expect(tooltipTriggerElem.getAttribute('ng-reflect-popover-text')).toEqual('I am the info');
     });
 
-    // TODO: Should have written tests for id and for attributes.
+    it('should have required attributes', () => {
+      fixture.componentRef.setInput('id', 'cool-label-1');
+      fixture.componentRef.setInput('for', 'cool-component-3');
+      fixture.detectChanges();
+
+      const elem = fixture.debugElement.query(By.css('label'));
+      expect(elem.nativeElement.getAttribute('id')).toEqual('cool-label-1');
+      expect(elem.nativeElement.getAttribute('for')).toEqual('cool-component-3');
+    });
   });
 });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.html
@@ -20,7 +20,7 @@
     [id]="id"
     [attr.tabindex]="disabled ? -1 : null"
     [attr.aria-describedby]="id + '_guidance'"
-    [attr.aria-invalid]="control.invalid || null"
+    [attr.aria-invalid]="(control.invalid && control.touched) || null"
     [attr.minLength]="_minLength | async"
     [attr.maxLength]="_maxLength | async"
     [attr.required]="(_required | async) || null"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule, FormControl } from '@angular/forms';
 import { TextAreaComponent } from './text-area.component';
@@ -53,35 +54,26 @@ describe('TextAreaComponent', () => {
   }
 
   it('should init the component successfully', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { _updateValueAndValidityTrigger } = component as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     jest.spyOn(component as any, '_setControlValueSubscription');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     jest.spyOn(component as any, '_setComponentId');
     jest.spyOn(_updateValueAndValidityTrigger, 'next');
 
     fixture.detectChanges();
 
     expect(_updateValueAndValidityTrigger.next).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((component as any)._setControlValueSubscription).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((component as any)._setComponentId).toHaveBeenCalledTimes(1);
   });
 
   it('should destroy the component successfully', () => {
     fixture.detectChanges();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((component as any)._subscription.closed).toBeFalsy();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((component as any)._baseSubscription.closed).toBeFalsy();
 
     fixture.destroy();
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((component as any)._subscription.closed).toBeTruthy();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((component as any)._baseSubscription.closed).toBeTruthy();
   });
 
@@ -109,17 +101,6 @@ describe('TextAreaComponent', () => {
       component.control.valueChanges.subscribe(() => (didEmit = true));
       fixture.detectChanges();
       expect(didEmit).toBeFalsy();
-    });
-
-    it('should unsubscribe on destroy', () => {
-      fixture.detectChanges();
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((component as any)._subscription.closed).toBeFalsy();
-
-      fixture.destroy();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((component as any)._subscription.closed).toBeTruthy();
     });
 
     it('should set control as invalid if required textarea is touched and empty', () => {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.spec.ts
@@ -73,7 +73,7 @@ describe('TextAreaComponent', () => {
   it('should destroy the component successfully', () => {
     fixture.detectChanges();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((component as any)._subscription.isStopped).toBeFalsy();
+    expect((component as any)._subscription.closed).toBeFalsy();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((component as any)._baseSubscription.closed).toBeFalsy();
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.spec.ts
@@ -10,6 +10,7 @@ import { IconComponent } from '../../icon/icon.component';
 import { getElement } from '../../../utilities/tests/utilities';
 import { FudisInternalErrorSummaryService } from '../../../services/form/error-summary/internal-error-summary.service';
 import { PopoverDirective } from '../../../directives/popover/popover.directive';
+import { ValidatorErrorMessageComponent } from '../error-message/validator-error-message/validator-error-message.component';
 
 const textAreaControl: FormControl = new FormControl('');
 
@@ -25,6 +26,7 @@ describe('TextAreaComponent', () => {
         GuidanceComponent,
         IconComponent,
         LabelComponent,
+        ValidatorErrorMessageComponent,
       ],
       imports: [ReactiveFormsModule, PopoverDirective],
       providers: [FudisInternalErrorSummaryService],
@@ -68,6 +70,21 @@ describe('TextAreaComponent', () => {
     expect((component as any)._setComponentId).toHaveBeenCalledTimes(1);
   });
 
+  it('should destroy the component successfully', () => {
+    fixture.detectChanges();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((component as any)._subscription.isStopped).toBeFalsy();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((component as any)._baseSubscription.closed).toBeFalsy();
+
+    fixture.destroy();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((component as any)._subscription.closed).toBeTruthy();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((component as any)._baseSubscription.closed).toBeTruthy();
+  });
+
   describe('HTML attributes', () => {
     beforeEach(() => fixture.detectChanges());
 
@@ -106,11 +123,22 @@ describe('TextAreaComponent', () => {
     });
 
     it('should set control as invalid if required textarea is touched and empty', () => {
+      fixture.componentRef.setInput(
+        'control',
+        new FormControl('', FudisValidators.required('This is required')),
+      );
       fixture.detectChanges();
-      component.control = new FormControl('', FudisValidators.required('This is required'));
 
       expect(component.control.value).toEqual('');
-      expect(component.control.invalid).toBeTruthy();
+
+      let inputElement = getElement(fixture, 'textarea');
+      expect(inputElement.getAttribute('aria-invalid')).toEqual(null);
+
+      component.control.markAsTouched();
+      fixture.detectChanges();
+
+      inputElement = getElement(fixture, 'textarea');
+      expect(inputElement.getAttribute('aria-invalid')).toEqual('true');
     });
 
     it('should set control as invalid if text is too short according to given minLength validator value', () => {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-area/text-area.component.spec.ts
@@ -184,12 +184,10 @@ describe('TextAreaComponent', () => {
       fixture.componentRef.setInput('popoverText', 'This is popover text');
       fixture.detectChanges();
 
-      const tooltipTriggerElem = getElement(fixture, 'fudis-button');
+      const tooltipTriggerElem = getElement(fixture, 'button');
 
       expect(tooltipTriggerElem).toBeTruthy();
-      expect(tooltipTriggerElem.getAttribute('ng-reflect-aria-label')).toEqual(
-        'Additional information',
-      );
+      expect(tooltipTriggerElem.getAttribute('aria-label')).toEqual('Additional information');
       expect(tooltipTriggerElem.getAttribute('ng-reflect-popover-text')).toEqual(
         'This is popover text',
       );

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.html
@@ -12,7 +12,7 @@
   <input
     #inputRef
     class="fudis-form-input fudis-text-input__input"
-    [attr.aria-invalid]="control.invalid || null"
+    [attr.aria-invalid]="(control.invalid && control.touched) || null"
     [attr.aria-label]="ariaLabel"
     [formControl]="control"
     [attr.minlength]="_minLength | async"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.spec.ts
@@ -10,6 +10,7 @@ import { FudisValidators } from '../../../utilities/form/validators';
 import { getElement } from '../../../utilities/tests/utilities';
 import { FudisInternalErrorSummaryService } from '../../../services/form/error-summary/internal-error-summary.service';
 import { PopoverDirective } from '../../../directives/popover/popover.directive';
+import { ValidatorErrorMessageComponent } from '../error-message/validator-error-message/validator-error-message.component';
 
 const textInputControl: FormControl = new FormControl('');
 
@@ -25,6 +26,7 @@ describe('TextInputComponent', () => {
         IconComponent,
         LabelComponent,
         TextInputComponent,
+        ValidatorErrorMessageComponent,
       ],
       imports: [ReactiveFormsModule, PopoverDirective],
       providers: [FudisInternalErrorSummaryService],
@@ -78,6 +80,21 @@ describe('TextInputComponent', () => {
     expect((component as any)._setComponentId).toHaveBeenCalledTimes(1);
   });
 
+  it('should destroy the component successfully', () => {
+    fixture.detectChanges();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((component as any)._subscription.isStopped).toBeFalsy();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((component as any)._baseSubscription.closed).toBeFalsy();
+
+    fixture.destroy();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((component as any)._subscription.closed).toBeTruthy();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((component as any)._baseSubscription.closed).toBeTruthy();
+  });
+
   describe('HTML attributes', () => {
     beforeEach(() => fixture.detectChanges());
 
@@ -125,16 +142,32 @@ describe('TextInputComponent', () => {
     });
 
     it('should set control as invalid if required text-input is touched and empty', () => {
+      fixture.componentRef.setInput(
+        'control',
+        new FormControl('', FudisValidators.required('This field is required')),
+      );
       fixture.detectChanges();
-      component.control = new FormControl('', FudisValidators.required('This field is required'));
+
+      let inputElement = getElement(fixture, 'input');
 
       expect(component.control.value).toEqual('');
       expect(component.control.invalid).toBeTruthy();
+      expect(inputElement.getAttribute('aria-invalid')).toEqual(null);
+
+      component.control.markAsTouched();
+      fixture.detectChanges();
+
+      inputElement = getElement(fixture, 'input');
+      expect(inputElement.getAttribute('aria-invalid')).toEqual('true');
     });
 
     it('should set control as invalid if text is too short according to given minLength validator value', () => {
+      fixture.componentRef.setInput(
+        'control',
+        new FormControl('', [FudisValidators.minLength(10, 'Too short')]),
+      );
       fixture.detectChanges();
-      component.control = new FormControl('', [FudisValidators.minLength(10, 'Too short')]);
+
       component.control.patchValue('too short');
 
       expect(component.control.value).toEqual('too short');
@@ -142,8 +175,12 @@ describe('TextInputComponent', () => {
     });
 
     it('should set control as invalid if text is too long according to given maxLength validator value', () => {
+      fixture.componentRef.setInput(
+        'control',
+        new FormControl('', [FudisValidators.maxLength(10, 'Too long text')]),
+      );
       fixture.detectChanges();
-      component.control = new FormControl('', [FudisValidators.maxLength(10, 'Too long text')]);
+
       component.control.patchValue('too longy long text');
 
       expect(component.control.value).toEqual('too longy long text');
@@ -151,8 +188,12 @@ describe('TextInputComponent', () => {
     });
 
     it('should set control as invalid if number is not respective to given min validator value', () => {
+      fixture.componentRef.setInput(
+        'control',
+        new FormControl('', [FudisValidators.min(1, 'Too small')]),
+      );
       fixture.detectChanges();
-      component.control = new FormControl('', [FudisValidators.min(1, 'Too small')]);
+
       component.control.patchValue('-10');
 
       expect(component.control.value).toEqual('-10');
@@ -160,10 +201,12 @@ describe('TextInputComponent', () => {
     });
 
     it('should set control as invalid if number is not respective to given max validator value', () => {
+      fixture.componentRef.setInput(
+        'control',
+        new FormControl('', [FudisValidators.max(99, 'The given number is too big')]),
+      );
       fixture.detectChanges();
-      component.control = new FormControl('', [
-        FudisValidators.max(99, 'The given number is too big'),
-      ]);
+
       component.control.patchValue('210');
 
       expect(component.control.value).toEqual('210');

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.spec.ts
@@ -83,7 +83,7 @@ describe('TextInputComponent', () => {
   it('should destroy the component successfully', () => {
     fixture.detectChanges();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((component as any)._subscription.isStopped).toBeFalsy();
+    expect((component as any)._subscription.closed).toBeFalsy();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((component as any)._baseSubscription.closed).toBeFalsy();
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/text-input/text-input.component.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { TextInputComponent } from './text-input.component';
@@ -63,35 +64,26 @@ describe('TextInputComponent', () => {
   }
 
   it('should init the component successfully', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { _updateValueAndValidityTrigger } = component as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     jest.spyOn(component as any, '_setControlValueSubscription');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     jest.spyOn(component as any, '_setComponentId');
     jest.spyOn(_updateValueAndValidityTrigger, 'next');
 
     fixture.detectChanges();
 
     expect(_updateValueAndValidityTrigger.next).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((component as any)._setControlValueSubscription).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((component as any)._setComponentId).toHaveBeenCalledTimes(1);
   });
 
   it('should destroy the component successfully', () => {
     fixture.detectChanges();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((component as any)._subscription.closed).toBeFalsy();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((component as any)._baseSubscription.closed).toBeFalsy();
 
     fixture.destroy();
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((component as any)._subscription.closed).toBeTruthy();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((component as any)._baseSubscription.closed).toBeTruthy();
   });
 
@@ -128,17 +120,6 @@ describe('TextInputComponent', () => {
       component.control.valueChanges.subscribe(() => (didEmit = true));
       fixture.detectChanges();
       expect(didEmit).toBeFalsy();
-    });
-
-    it('should unsubscribe on destroy', () => {
-      fixture.detectChanges();
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((component as any)._subscription.closed).toBeFalsy();
-
-      fixture.destroy();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((component as any)._subscription.closed).toBeTruthy();
     });
 
     it('should set control as invalid if required text-input is touched and empty', () => {


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-263

Update tests and update aria-invalid to true only after it has been marked as touched.

Additional ticket made about `ng-touched` not triggering OnPush components properly https://funidata.atlassian.net/browse/DS-475