### PR TITLE
Small updates to and hardening of GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -31,6 +31,6 @@ jobs:
           path-to-document: "https://github.com/funidata/fudis/blob/main/CLA"
           branch: "main"
           # Add users here to bypass CLA requirements (teams/orgs not supported).
-          allowlist: "dependabot[bot],videoeero,RiinaKuu,Aleksuo,MayaMarjut,marisanity"
+          allowlist: "dependabot[bot],RiinaKuu,Aleksuo,MayaMarjut,marisanity"
           remote-organization-name: funidata
           remote-repository-name: cla-signature-store

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Run CLA Assistant Action
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.3.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURE_STORE_TOKEN }}

--- a/.github/workflows/delete_branch_docs.yaml
+++ b/.github/workflows/delete_branch_docs.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Delete docs from S3 bucket
         run: aws s3 rm s3://${{ secrets.AWS_S3_BUCKET_NAME }}/branch/${{ github.event.ref }} --recursive
       - name: Deactivate deployment
-        uses: bobheadxi/deployments@v1
+        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8
         with:
           step: deactivate-env
           env: Documentation for branch ${{ github.event.ref }}

--- a/.github/workflows/publish_docs_from_pr.yaml
+++ b/.github/workflows/publish_docs_from_pr.yaml
@@ -17,7 +17,7 @@ jobs:
         working-directory: ngx-fudis
     steps:
       - name: Start deployment
-        uses: bobheadxi/deployments@v1
+        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8
         id: deployment
         with:
           step: start
@@ -41,7 +41,7 @@ jobs:
       - name: Copy docs to S3 bucket
         run: aws s3 sync static s3://${{ secrets.AWS_S3_BUCKET_NAME }}/branch/${{ github.ref_name }} --delete --cache-control max-age=5
       - name: Finish deployment
-        uses: bobheadxi/deployments@v1
+        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8
         if: always()
         with:
           step: finish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
       # Recent Node.js is included in `ubuntu-latest` but `setup-node` is still required to setup NPM auth via token.
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           # Specifying `registry-url` triggers `setup-node` to setup NPM authentication.

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -108,7 +108,7 @@ jobs:
           path: coverage
       - name: Comment Coverage Summary on PR
         if: github.event_name == 'pull_request'
-        uses: MishaKav/jest-coverage-comment@main
+        uses: MishaKav/jest-coverage-comment@d74238813c33e6ea20530ff91b5ea37953d11c91
         with:
           coverage-summary-path: coverage/coverage-summary.json
           coverage-path: coverage/coverage.txt


### PR DESCRIPTION
I went through [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) and reviewed our workflows to be on par with GitHub's instructions. Mostly, everything looks to be fine.

As a precaution, I pinned some third-party actions to SHA's instead of version tags or branches, as they were earlier. I figured the actions authored by GitHub, Docker, and AWS to be trusted and left those pinned on major versions to benefit from bug and vulnerability fixes, etc. For the actions that I pinned to SHA's, I did a really quick and light review on repository-level to check that there are no obvious reported vulnerabilities or other funny things going on. (Do not consider those actions to be vetted based on this – we can discuss internally, if we wan't to do a more robust code review on them.)

Also removed Eero from CLA allowlist 🥲