### PR TITLE
[Guidance]: Unify maxLength indicator screen reader prompts

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dialog/dialog.mdx
@@ -14,6 +14,8 @@ Fudis Dialog consists of three parts: Service, Component and Directives.
 
 It is recommended to have only one Dialog open at a time.
 
+The first heading of the dialog should be either level 1 or 2. The Dialog heading levels should be used consistently throughout the application.
+
 Pay attention to accessibility when using dialog with read-only content.
 
 ## Service

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.html
@@ -85,7 +85,8 @@
       <ng-container *ngIf="helpText">{{ helpText }}</ng-container>
       <ng-container *ngIf="control && maxLength">
         <span class="fudis-visually-hidden"
-          >{{ control.value?.length || 0 }}/{{ maxLength }} {{ _maxLengthText | async }}</span
+          >&nbsp; {{ control.value?.length || 0 }}/{{ maxLength }}
+          {{ _maxLengthText | async }}</span
         >
       </ng-container>
     </p>
@@ -122,7 +123,8 @@
         <p
           class="fudis-guidance__character-limit-indicator__alert fudis-visually-hidden"
           role="alert"
-          >{{ singleControl.value.value?.length || 0 }}/{{ maxLength }}
+        >
+          &nbsp; {{ singleControl.value.value?.length || 0 }}/{{ maxLength }}
           {{ _maxLengthText | async }}</p
         >
       </ng-container>
@@ -137,6 +139,6 @@
   "
 >
   <p class="fudis-guidance__character-limit-indicator__alert fudis-visually-hidden" role="alert"
-    >{{ control.value?.length || 0 }}/{{ maxLength }} {{ _maxLengthText | async }}</p
+    >&nbsp; {{ control.value?.length || 0 }}/{{ maxLength }} {{ _maxLengthText | async }}</p
   >
 </ng-container>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.html
@@ -83,36 +83,30 @@
 
     <p *ngIf="helpText || (control && maxLength)" class="fudis-guidance__help-text">
       <ng-container *ngIf="helpText">{{ helpText }}</ng-container>
-      <ng-container *ngIf="control && maxLength">
-        <span class="fudis-visually-hidden"
-          >&nbsp; {{ control.value?.length || 0 }}/{{ maxLength }}
-          {{ _maxLengthText | async }}</span
-        >
-      </ng-container>
     </p>
   </div>
   <ng-container *ngIf="maxLength && control">
     <small
-      aria-hidden="true"
       class="fudis-guidance__character-limit-indicator fudis-guidance__character-limit-indicator__{{
         _maxLengthWidth
       }}"
       [class.fudis-guidance__character-limit-indicator__float-right]="!helpText"
     >
       {{ control.value?.length || 0 }}/{{ maxLength }}
+      <span class="fudis-visually-hidden">{{ _maxLengthText | async }}</span>
     </small>
   </ng-container>
   <ng-container *ngIf="formGroup?.controls && !control && maxLength">
     <ng-container *ngFor="let singleControl of formGroup?.controls | keyvalue">
       <small
         *ngIf="singleControl.key === selectedOption"
-        aria-hidden="true"
         class="fudis-guidance__character-limit-indicator fudis-guidance__character-limit-indicator__{{
           _maxLengthWidth
         }}"
         [class.fudis-guidance__character-limit-indicator__float-right]="!helpText"
       >
         {{ singleControl.value.value?.length || 0 }}/{{ maxLength }}
+        <span class="fudis-visually-hidden">{{ _maxLengthText | async }}</span>
       </small>
       <ng-container
         *ngIf="
@@ -124,7 +118,7 @@
           class="fudis-guidance__character-limit-indicator__alert fudis-visually-hidden"
           role="alert"
         >
-          &nbsp; {{ singleControl.value.value?.length || 0 }}/{{ maxLength }}
+          {{ singleControl.value.value?.length || 0 }}/{{ maxLength }}
           {{ _maxLengthText | async }}</p
         >
       </ng-container>
@@ -139,6 +133,6 @@
   "
 >
   <p class="fudis-guidance__character-limit-indicator__alert fudis-visually-hidden" role="alert"
-    >&nbsp; {{ control.value?.length || 0 }}/{{ maxLength }} {{ _maxLengthText | async }}</p
+    >{{ control.value?.length || 0 }}/{{ maxLength }} {{ _maxLengthText | async }}</p
   >
 </ng-container>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.html
@@ -92,6 +92,7 @@
   </div>
   <ng-container *ngIf="maxLength && control">
     <small
+      aria-hidden="true"
       class="fudis-guidance__character-limit-indicator fudis-guidance__character-limit-indicator__{{
         _maxLengthWidth
       }}"
@@ -104,6 +105,7 @@
     <ng-container *ngFor="let singleControl of formGroup?.controls | keyvalue">
       <small
         *ngIf="singleControl.key === selectedOption"
+        aria-hidden="true"
         class="fudis-guidance__character-limit-indicator fudis-guidance__character-limit-indicator__{{
           _maxLengthWidth
         }}"


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-447

- Unify screen reader functionality so that it works similarly in LocalizedTextGroup and basic text inputs. 
    - _"x/xx characters used"_ is now always read in its own block after helpText and not within helpText. 
     - Threshold warning functionality stays the same.

- Added suggestion for Dialog's documentation about heading level