### PR TITLE
[Button]: CSS class fix for icon-only button

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.spec.ts
@@ -8,7 +8,6 @@ import {
 } from '../../types/miscellaneous';
 import { getElement, sortClasses } from '../../utilities/tests/utilities';
 import { fudisIconRotateArray } from '../../types/icons';
-import { PopoverDirective } from '../../directives/popover/popover.directive';
 
 describe('ButtonComponent', () => {
   let component: ButtonComponent;
@@ -17,7 +16,6 @@ describe('ButtonComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ButtonComponent, IconComponent],
-      imports: [PopoverDirective],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ButtonComponent);
@@ -43,11 +41,19 @@ describe('ButtonComponent', () => {
           fixture.componentRef.setInput('size', `${size}`);
           fixture.detectChanges();
 
-          expect(sortClasses(getButton().className)).toEqual(
-            sortClasses(
-              `fudis-button fudis-button__label--visible fudis-button__${variant} fudis-button__size__${size}`,
-            ),
-          );
+          if (component.size === 'icon-only') {
+            expect(sortClasses(getButton().className)).toEqual(
+              sortClasses(
+                `fudis-button fudis-button__label--hidden fudis-button__${variant} fudis-button__size__${size}`,
+              ),
+            );
+          } else {
+            expect(sortClasses(getButton().className)).toEqual(
+              sortClasses(
+                `fudis-button fudis-button__label--visible fudis-button__${variant} fudis-button__size__${size}`,
+              ),
+            );
+          }
         });
       });
     });
@@ -145,7 +151,7 @@ describe('ButtonComponent', () => {
       expect(getButton().getAttribute('aria-expanded')).toEqual('true');
 
       expect(getButton().getAttribute('aria-label')).toEqual(
-        'Open additional menu It has nice things to click',
+        'Open additional menu, It has nice things to click',
       );
 
       expect(getButton().getAttribute('type')).toEqual('button');

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.ts
@@ -261,7 +261,7 @@ export class ButtonComponent extends TooltipApiDirective implements OnChanges, O
    */
   private _getAriaLabel(): string {
     if (this.labelHidden || this.size === 'icon-only') {
-      return this.ariaLabel ? `${this.label} ${this.ariaLabel}` : this.label;
+      return this.ariaLabel ? `${this.label}, ${this.ariaLabel}` : this.label;
     }
     return this.ariaLabel;
   }
@@ -278,7 +278,7 @@ export class ButtonComponent extends TooltipApiDirective implements OnChanges, O
       this._iconColor.next('primary');
     }
 
-    if (this.labelHidden) {
+    if (this.labelHidden || this.size === 'icon-only') {
       return [
         'fudis-button',
         `fudis-button__size__${this.size}`,

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.stories.ts
@@ -193,12 +193,7 @@ export const AllVariants: StoryFn = (args) => ({
       <fudis-heading class="fudis-mt-lg" [level]="4" [variant]="'sm'"
         >Icon only sized buttons with label hidden</fudis-heading
       >
-      <fudis-button
-        variant="primary"
-        icon="search"
-        label="Primary"
-        size="icon-only"
-      ></fudis-button>
+      <fudis-button variant="primary" icon="search" label="Primary" size="icon-only"></fudis-button>
       <fudis-button
         variant="secondary"
         icon="search"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.stories.ts
@@ -58,7 +58,7 @@ Example.args = {
   ariaLabel: undefined,
   size: 'medium',
   icon: undefined,
-  iconRotate: undefined,
+  iconRotate: 'none',
   disabled: false,
 };
 
@@ -69,7 +69,7 @@ WithIcon.args = {
   ariaLabel: undefined,
   size: 'medium',
   icon: 'search',
-  iconRotate: undefined,
+  iconRotate: 'none',
   disabled: false,
 };
 
@@ -77,10 +77,10 @@ export const IconOnly = Template.bind({});
 IconOnly.args = {
   variant: 'secondary',
   label: 'Search button',
-  ariaLabel: undefined,
+  ariaLabel: 'Additional aria-label',
   size: 'medium',
   icon: 'search',
-  iconRotate: undefined,
+  iconRotate: 'none',
   labelHidden: true,
   disabled: false,
 };
@@ -195,28 +195,24 @@ export const AllVariants: StoryFn = (args) => ({
       >
       <fudis-button
         variant="primary"
-        [labelHidden]="true"
         icon="search"
         label="Primary"
         size="icon-only"
       ></fudis-button>
       <fudis-button
         variant="secondary"
-        [labelHidden]="true"
         icon="search"
         label="Secondary"
         size="icon-only"
       ></fudis-button>
       <fudis-button
         variant="tertiary"
-        [labelHidden]="true"
         icon="search"
         label="Tertiary"
         size="icon-only"
       ></fudis-button>
       <fudis-button
         label="Disabled"
-        [labelHidden]="true"
         icon="search"
         [disabled]="true"
         size="icon-only"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/popover/popover.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/popover/popover.mdx
@@ -24,7 +24,6 @@ Following components implement Popover Directive to apply popover in semanticall
 - [Section](/docs/components-section--documentation)
 - [MultiSelect](/docs/components-form-select-multiselect--documentation)
 - [Select](/docs/components-form-select-select--documentation)
-- [Button](/docs/components-button--documentation)
 - [FieldSet](/docs/components-form-fieldset--documentation)
 - [Localized Text Group](/docs/components-form-localized-text-group--documentation)
 - [Radio Button Group](/docs/components-form-radio-button-group--documentation)

--- a/ngx-fudis/projects/ngx-fudis/src/lib/utilities/storybook.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/utilities/storybook.ts
@@ -97,6 +97,9 @@ const buttonCommonExclude: string[] = [
   'tooltipPosition',
   'tooltipToggle',
   'popoverTriggerLabel',
+  'popoverPosition',
+  'popoverText',
+  'id',
 ];
 
 export const buttonExclude: RegExp = excludeRegex([...buttonCommonExclude]);


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-476

- Fixed CSS class with `[size]="'icon-only'"` button
   - `fudis-button__label--visible` --> `fudis-button__label--hidden`
- Removed popover controls from Button stories
    - We don't want to enforce popover usage directly in button
    - Two click events in one element is not accessible