### PR TITLE
[Notification]: Replace attention text from ARIA to its own hidden paragraph

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/notification.component.html
@@ -1,9 +1,7 @@
-<article
-  #articleElement
-  tabindex="-1"
-  class="fudis-notification fudis-notification__{{ variant }}"
-  [attr.aria-label]="_translateService.getTranslations()().ATTENTION"
->
+<article #articleElement tabindex="-1" class="fudis-notification fudis-notification__{{ variant }}">
+  <fudis-body-text class="fudis-visually-hidden">{{
+    _translateService.getTranslations()().ATTENTION
+  }}</fudis-body-text>
   <fudis-icon *ngIf="variant === 'warning'" [icon]="'exclamation-mark-circle'" />
   <fudis-icon *ngIf="variant === 'danger'" [icon]="'alert'" />
   <fudis-icon *ngIf="variant === 'success'" [icon]="'checkmark-circle'" />

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/readme.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/notification/readme.mdx
@@ -33,9 +33,10 @@ Please see code examples for recommended usage patterns.
 
 ### Accessibility
 
-- Notification background and text color contrast ratio meets AA and AAA levels.
-- Notification content is accessible by screen readers.
-- External link is communicated to screen reader with assistive aria-label.
+- Notification background and text color contrast ratio meets AA and AAA levels
+- Notification content is accessible by screen readers
+- Notification component is native `article` element
+- External link is communicated to screen reader with assistive aria-label
 
 ### Related components
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/utilities/storybook.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/utilities/storybook.ts
@@ -343,7 +343,13 @@ export const linkExclude: RegExp = excludeRegex([
 /**
  * Notification
  */
-export const notificationExclude: RegExp = excludeRegex(['link', 'linkTitle', 'externalLink']);
+export const notificationExclude: RegExp = excludeRegex([
+  'link',
+  'linkTitle',
+  'externalLink',
+  'focus',
+  'articleElement',
+]);
 
 /**
  * Radio Button Group

--- a/test/visual-regression/error-summary.spec.ts
+++ b/test/visual-regression/error-summary.spec.ts
@@ -124,7 +124,7 @@ test("error summary language change and manually sent errors", async ({ page }) 
 
   await page.getByTestId("fudis-select-2").focus();
   await expect(
-    page.getByTestId("fudis-body-text-7").getByText("Näytetään 1 tulosta"),
+    page.getByTestId("fudis-body-text-8").getByText("Näytetään 1 tulosta"),
   ).toBeVisible();
   await expect(
     page.getByTestId("fudis-select-2-option-95nokf").getByText("R2-D2 (Astromekaanikkodroidi)"),


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-476

- Changed attention text from aria-label to its own visually-hidden paragraph
   - NVDA does not recognize native `article` element at all and therefore it does not announce any aria-attributes which are linked to that article element
   - Mentioned about article use in Notification documentation
 - Added missing Storybook control excules