### PR TITLE
[DropdownMenu]: HOTFIX circular dependency

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/dropdown-menu/dropdown-menu.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/dropdown-menu/dropdown-menu.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
+  forwardRef,
   Host,
   HostListener,
   Inject,
@@ -31,7 +32,9 @@ export class DropdownMenuComponent extends DropdownBaseDirective implements OnIn
   constructor(
     private _idService: FudisIdService,
     @Inject(DOCUMENT) private _document: Document,
-    @Host() private _parentButton: ButtonComponent,
+    // HOTFIX: ForwardRef does not resolve root cause of circular dependecy, but fixes issue in standalone project with Jest unit tests where this circularity was detected (Rane)
+    // TODO: Fix underlying circular dependency
+    @Host() @Inject(forwardRef(() => ButtonComponent)) private _parentButton: ButtonComponent,
   ) {
     super();
 


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-505

- Tested this hotfix in an example branch in client application side -> issue fixed
- Does not fix the root cause and is still found when detecting circular dependencies with [madge](https://github.com/pahen/madge)
   - `madge --circular --extensions ts ngx-fudis/projects/ngx-fudis/src/`
   - `lib/components/button/button.component.ts` > `lib/components/dropdown-menu/dropdown-menu.component.ts`
- There are three other issues and all of these shall be fixed in separate ticket/branch