### PR TITLE
Limit uploaded artifact retention period

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -23,3 +23,4 @@ jobs:
         with:
           name: fudis-test
           path: /tmp/fudis-test.image.tar
+          retention-days: 1

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -155,8 +155,10 @@ jobs:
         with:
           name: playwright-report
           path: test/playwright-report/
+          retention-days: 7
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-results
           path: test/test-results/
+          retention-days: 7


### PR DESCRIPTION
Apparently our increased usage of GitHub Actions has bloated the artifact storage. Some other repositories have been hitting the quota limit and it's shared across the organisation.

This PR especially limits the rather large Docker image to be retained for one day only (it is only needed during the test run so could be discarded immediately anyway). I also added `retention-period` to Playwright reports but it's the same as the current repository setting which `upload-artifact` defaults to, so doesn't really change anything expect makes the configuration more explicit.