### PR TITLE
[Datepicker, DateRange]: Date input parsing fix

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/date-common/utilities.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/date-common/utilities.ts
@@ -59,8 +59,8 @@ export const parseDate = (value: string | null | undefined): Date | null => {
         .map(Number)
     : null;
 
-  // If day, month and year are provided
-  if (numberArray?.length === 3) {
+  // If day, month and year are provided. Year must have 4 digits.
+  if (numberArray?.length === 3 && numberArray[2].toString().length === 4) {
     const newDate = new Date(numberArray[2], numberArray[1] - 1, numberArray[0]);
 
     const dayUnchanged = newDate.getDate() === numberArray[0];

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/date-range/date-range.stories.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/date-range/date-range.stories.ts
@@ -86,18 +86,18 @@ DateRange.args = {
 const TemplateDateRangeMinMax: StoryFn = (args) => ({
   props: {
     ...args,
-    controlStart: new FormControl<Date | null>(null, [
+    controlStart: new FormControl<Date | null>(new Date(2025, 4, 15), [
       FudisValidators.required('Date is required.'),
       FudisValidators.datepickerMin({
-        value: new Date(2024, 4, 15),
-        message: 'Start date cannot be earlier than 15.5.2024',
+        value: new Date(2025, 4, 15),
+        message: 'Start date cannot be earlier than 15.5.2025',
       }),
     ]),
-    controlEnd: new FormControl<Date | null>(null, [
+    controlEnd: new FormControl<Date | null>(new Date(2025, 5, 20), [
       FudisValidators.required('Date is required.'),
       FudisValidators.datepickerMax({
-        value: new Date(2024, 5, 20),
-        message: 'End date cannot be later than 20.6.2024',
+        value: new Date(2025, 5, 20),
+        message: 'End date cannot be later than 20.6.2025',
       }),
     ]),
   },
@@ -105,14 +105,14 @@ const TemplateDateRangeMinMax: StoryFn = (args) => ({
     <fudis-datepicker
       fudisDateStart
       [label]="'Start date'"
-      [helpText]="'Choose start date'"
+      [helpText]="'Show error by entering date before 15.5.2025'"
       [control]="controlStart"
       [dateParse]="dateParse"
     />
     <fudis-datepicker
       fudisDateEnd
       [label]="'End date'"
-      [helpText]="'Choose end date'"
+      [helpText]="'Show error by entering date after 20.6.2025'"
       [control]="controlEnd"
       [dateParse]="dateParse"
     />


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-479

In datepicker utilities functions, ensure that date input year value has 4 numbers. Otherwise show validation errors.
Also added more descriptive helptext to dateMin and dateMax validators, in order to produce errors.