### PR TITLE
[DateRange]: Trigger date crossing check properly (even if other datepicker is not touched)

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.ts
@@ -76,6 +76,7 @@ export class DatepickerComponent
               datepickerEndDateInvalid: { message: this._endDateInvalidTranslation },
             });
           }
+          this.control?.markAllAsTouched();
         } else {
           if (currentErrors) {
             delete currentErrors['datepickerStartDateInvalid'];
@@ -217,6 +218,17 @@ export class DatepickerComponent
 
     if (!this._parseValidatorInstance && this.dateParse) {
       this._addParseValidator();
+    }
+  }
+
+  override ngAfterViewInit(): void {
+    super.ngAfterViewInit();
+
+    const inputElValue = this._inputRef?.nativeElement?.value;
+    const isValidDate = inputElValue ? parseDate(inputElValue) : false;
+
+    if (isValidDate !== false) {
+      this._parentDateRange?.checkDateCrossings(isValidDate, this.dateRangeType!);
     }
   }
 


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-514

When DateRange has a pre set value from initialisation, check comparison errors in afterViewInit. 