### PR TITLE
Release 6.0.0-rc.2

### DIFF
--- a/ngx-fudis/package-lock.json
+++ b/ngx-fudis/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-fudis",
-  "version": "6.0.0-rc.0",
+  "version": "6.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-fudis",
-      "version": "6.0.0-rc.0",
+      "version": "6.0.0-rc.1",
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
         "@angular/animations": "^19.2.0",

--- a/ngx-fudis/package-lock.json
+++ b/ngx-fudis/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-fudis",
-  "version": "6.0.0-rc.1",
+  "version": "6.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-fudis",
-      "version": "6.0.0-rc.1",
+      "version": "6.0.0-rc.2",
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
         "@angular/animations": "^19.2.0",

--- a/ngx-fudis/package.json
+++ b/ngx-fudis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-fudis",
-  "version": "6.0.0-rc.1",
+  "version": "6.0.0-rc.2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/ngx-fudis/package.json
+++ b/ngx-fudis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-fudis",
-  "version": "6.0.0-rc.0",
+  "version": "6.0.0-rc.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/ngx-fudis/projects/ngx-fudis/package-lock.json
+++ b/ngx-fudis/projects/ngx-fudis/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@funidata/ngx-fudis",
-  "version": "6.0.0-rc.1",
+  "version": "6.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@funidata/ngx-fudis",
-      "version": "6.0.0-rc.1",
+      "version": "6.0.0-rc.2",
       "license": "CC-BY-NC-SA-4.0",
       "devDependencies": {
         "tslib": "^2.7.0",

--- a/ngx-fudis/projects/ngx-fudis/package-lock.json
+++ b/ngx-fudis/projects/ngx-fudis/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@funidata/ngx-fudis",
-  "version": "6.0.0-rc.0",
+  "version": "6.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@funidata/ngx-fudis",
-      "version": "6.0.0-rc.0",
+      "version": "6.0.0-rc.1",
       "license": "CC-BY-NC-SA-4.0",
       "devDependencies": {
         "tslib": "^2.7.0",

--- a/ngx-fudis/projects/ngx-fudis/package.json
+++ b/ngx-fudis/projects/ngx-fudis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funidata/ngx-fudis",
-  "version": "6.0.0-rc.0",
+  "version": "6.0.0-rc.1",
   "license": "CC-BY-NC-SA-4.0",
   "exports": {
     ".": {

--- a/ngx-fudis/projects/ngx-fudis/package.json
+++ b/ngx-fudis/projects/ngx-fudis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funidata/ngx-fudis",
-  "version": "6.0.0-rc.1",
+  "version": "6.0.0-rc.2",
   "license": "CC-BY-NC-SA-4.0",
   "exports": {
     ".": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fudis",
-  "version": "6.0.0-rc.0",
+  "version": "6.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fudis",
-      "version": "6.0.0-rc.0",
+      "version": "6.0.0-rc.1",
       "hasInstallScript": true,
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fudis",
-  "version": "6.0.0-rc.1",
+  "version": "6.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fudis",
-      "version": "6.0.0-rc.1",
+      "version": "6.0.0-rc.2",
       "hasInstallScript": true,
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fudis",
-  "version": "6.0.0-rc.0",
+  "version": "6.0.0-rc.1",
   "description": "Funidata Design System",
   "scripts": {
     "postinstall": "cd ngx-fudis && npm ci",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "cd ngx-fudis && npm run lint",
     "stylelint": "cd ngx-fudis && npm run stylelint",
     "version": "scripts/version_sub_projects.sh $npm_package_version",
-    "postversion": "git commit --amend -m \"Bump to version v$npm_package_version\" && git push && git push origin v$npm_package_version",
+    "postversion": "git commit --amend -m \"Bump to version v$npm_package_version\"",
     "format:check": "prettier --check ."
   },
   "author": "Funidata Ltd",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fudis",
-  "version": "6.0.0-rc.1",
+  "version": "6.0.0-rc.2",
   "description": "Funidata Design System",
   "scripts": {
     "postinstall": "cd ngx-fudis && npm ci",

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fudis-vr",
-  "version": "6.0.0-rc.0",
+  "version": "6.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fudis-vr",
-      "version": "6.0.0-rc.0",
+      "version": "6.0.0-rc.1",
       "hasInstallScript": true,
       "license": "CC-BY-NC-SA-4.0",
       "devDependencies": {

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fudis-vr",
-  "version": "6.0.0-rc.1",
+  "version": "6.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fudis-vr",
-      "version": "6.0.0-rc.1",
+      "version": "6.0.0-rc.2",
       "hasInstallScript": true,
       "license": "CC-BY-NC-SA-4.0",
       "devDependencies": {

--- a/test/package.json
+++ b/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fudis-vr",
-  "version": "6.0.0-rc.1",
+  "version": "6.0.0-rc.2",
   "description": "Visual regression tests for Fudis",
   "scripts": {
     "start": "npx playwright test --ui",

--- a/test/package.json
+++ b/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fudis-vr",
-  "version": "6.0.0-rc.0",
+  "version": "6.0.0-rc.1",
   "description": "Visual regression tests for Fudis",
   "scripts": {
     "start": "npx playwright test --ui",


### PR DESCRIPTION
Test release for https://funidata.atlassian.net/browse/DS-486.

Some mishaps during version increment:
- Created branch called `release-6.0.0-rc.1`
- Increased prerelease version with `npm version prerelease` which caused npm error ("command failed")
  - Failed to do git push in `postversion` script
    - Deleted git push from the command, only leaving git commit (fyi, it is not present in Core either)
- New git tag (v6.0.0-rc.1) was created so I deleted it locally and from remote
- Ran `npm version prerelease` again
  - Successful increment but it detected that rc.1 was already existing so it created v6.0.0-rc.2 tag and did respective version increments (hence the misleading branch name vs. version increment)