### PR TITLE
[Storybook]: URL redirect path

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -24,6 +24,9 @@ changelog:
     - title: "Dependencies"
       labels:
         - "dependencies"
+    - title: "Github Actions"
+      labels:
+        - "github actions"
     - title: "Other"
       labels:
         - "*"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,4 +112,4 @@ jobs:
           <meta http-equiv='refresh' content='0; url=https://fudis.funidata.fi/ngx/v/$VERSION/index.html' />
           </head>
           </html>" > /tmp/index.html
-          aws s3 cp /tmp/index.html s3://${{ secrets.AWS_S3_BUCKET_NAME }} --cache-control max-age=5
+          aws s3 cp /tmp/index.html s3://${{ secrets.AWS_S3_BUCKET_NAME }}/ngx --cache-control max-age=5


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-486

In [this PR](https://github.com/funidata/fudis/pull/610), there were changes to Github release workflow but there was one missing path fix
  - **fudis.funidata.fi** root URL should not redirect to Ngx Storybook anymore
    - Root URL will redirect to the new landing page (WIP in Core repo, [PR](https://github.com/funidata/fudis-core/pull/39))
  - Only **fudis.funidata.fi/ngx** should redirect to the latest deployed Ngx Storybook version


Extra:
- Also noticed that our Github Actions label is missing from the Github release labels which are used to categorize pull requests in Github release notes.