### PR TITLE
[Components]: Circular dependencies detected in few components

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/button/button.component.ts
@@ -22,7 +22,7 @@ import {
   FudisComponentChanges,
 } from '../../types/miscellaneous';
 import { BehaviorSubject } from 'rxjs';
-import { DropdownMenuComponent } from '../dropdown-menu/dropdown-menu.component';
+import { DropdownEventService } from '../../services/dropdown/dropdown-event.service';
 
 @Component({
   selector: 'fudis-button',
@@ -33,7 +33,10 @@ import { DropdownMenuComponent } from '../dropdown-menu/dropdown-menu.component'
   standalone: false,
 })
 export class ButtonComponent extends TooltipApiDirective implements OnChanges, OnInit, OnDestroy {
-  constructor(private _idService: FudisIdService) {
+  constructor(
+    private _idService: FudisIdService,
+    private _dropdownEventService: DropdownEventService,
+  ) {
     super();
   }
 
@@ -203,7 +206,7 @@ export class ButtonComponent extends TooltipApiDirective implements OnChanges, O
     const newState = !this.dropdownOpen.value;
     this.dropdownOpen.next(newState);
 
-    DropdownMenuComponent.fireMaxWidthCalcEvent.next(true);
+    this._dropdownEventService.triggerWidthCalculation();
   }
 
   /**
@@ -216,7 +219,7 @@ export class ButtonComponent extends TooltipApiDirective implements OnChanges, O
       this.buttonEl.nativeElement.focus();
     }
 
-    DropdownMenuComponent.fireMaxWidthCalcEvent.next(true);
+    this._dropdownEventService.triggerWidthCalculation();
   }
 
   /**

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/interfaces/base-selectable.interface.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/interfaces/base-selectable.interface.ts
@@ -1,0 +1,8 @@
+import { FormControl } from '@angular/forms';
+import { FudisSelectVariant } from '../../../../../types/forms';
+
+export interface BaseSelectableComponent<T = unknown> {
+  control: FormControl<T>;
+  variant: FudisSelectVariant;
+  autocompleteFilter: boolean;
+}

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-base/select-base.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/select-base/select-base.directive.ts
@@ -14,22 +14,19 @@ import {
   signal,
   AfterViewInit,
 } from '@angular/core';
-
 import { FudisIdService } from '../../../../../services/id/id.service';
 import { FudisFocusService } from '../../../../../services/focus/focus.service';
 import { FudisInputSize, FudisSelectVariant } from '../../../../../types/forms';
 import { setVisibleOptionsList } from '../utilities/selectUtilities';
 import { SelectDropdownComponent } from '../select-dropdown/select-dropdown.component';
-
 import { FudisComponentChanges } from '../../../../../types/miscellaneous';
-import { SelectComponent } from '../../select/select.component';
-import { MultiselectComponent } from '../../multiselect/multiselect.component';
 import { FudisValidatorUtilities } from '../../../../../utilities/form/validator-utilities';
 import { DOCUMENT } from '@angular/common';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ControlComponentBaseDirective } from '../../../../../directives/form/control-component-base/control-component-base.directive';
 import { SelectOptionsDirective } from '../select-options-directive/select-options.directive';
 import { Subscription } from 'rxjs';
+import { BaseSelectableComponent } from '../interfaces/base-selectable.interface';
 
 @Directive({
   selector: '[fudisSelectBase]',
@@ -234,7 +231,7 @@ export class SelectBaseDirective
    */
   protected _clearButtonClickTrigger = signal<boolean>(false);
 
-  ngOnChanges(changes: FudisComponentChanges<SelectComponent | MultiselectComponent>): void {
+  ngOnChanges(changes: FudisComponentChanges<BaseSelectableComponent>): void {
     if (changes.control?.currentValue !== changes.control?.previousValue) {
       this._updateValueAndValidityTrigger.next();
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect.component.ts
@@ -17,6 +17,7 @@ import { SelectBaseDirective } from '../common/select-base/select-base.directive
 import { FudisSelectOption } from '../../../../types/forms';
 import { DOCUMENT } from '@angular/common';
 import { MultiselectControlValueAccessorDirective } from '../common/select-control-value-accessor/select-control-value-accessor.directive';
+import { BaseSelectableComponent } from '../common/interfaces/base-selectable.interface';
 
 @Component({
   selector: 'fudis-multiselect',
@@ -24,7 +25,10 @@ import { MultiselectControlValueAccessorDirective } from '../common/select-contr
   styleUrls: ['../select/select.component.scss'],
   standalone: false,
 })
-export class MultiselectComponent extends SelectBaseDirective implements OnInit {
+export class MultiselectComponent
+  extends SelectBaseDirective
+  implements OnInit, BaseSelectableComponent
+{
   constructor(
     @Inject(DOCUMENT) _document: Document,
     protected _translationService: FudisTranslationService,

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/select/select.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/select/select.component.ts
@@ -17,6 +17,7 @@ import { SelectBaseDirective } from '../common/select-base/select-base.directive
 import { FudisSelectOption } from '../../../../types/forms';
 import { DOCUMENT } from '@angular/common';
 import { SelectControlValueAccessorDirective } from '../common/select-control-value-accessor/select-control-value-accessor.directive';
+import { BaseSelectableComponent } from '../common/interfaces/base-selectable.interface';
 
 @Component({
   selector: 'fudis-select',
@@ -25,7 +26,10 @@ import { SelectControlValueAccessorDirective } from '../common/select-control-va
   encapsulation: ViewEncapsulation.None,
   standalone: false,
 })
-export class SelectComponent extends SelectBaseDirective implements OnInit, AfterViewInit {
+export class SelectComponent
+  extends SelectBaseDirective
+  implements OnInit, AfterViewInit, BaseSelectableComponent
+{
   constructor(
     @Inject(DOCUMENT) _document: Document,
     _idService: FudisIdService,

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/dropdown/dropdown-event.service.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/dropdown/dropdown-event.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+/**
+ * Dropdown event service shared between Button and DropdownMenu components.
+ *
+ * Dropdown menu element's width calculation must be triggered from host Button click, and it should
+ * ensure that the dropdown is always fully visible.
+ */
+
+@Injectable({ providedIn: 'root' })
+export class DropdownEventService {
+  private _triggerCalculationSubject = new Subject<void>();
+
+  triggerCalculation = this._triggerCalculationSubject.asObservable();
+
+  triggerWidthCalculation() {
+    this._triggerCalculationSubject.next();
+  }
+}

--- a/ngx-fudis/projects/ngx-fudis/src/lib/types/breakpoint-keys.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/types/breakpoint-keys.ts
@@ -1,0 +1,6 @@
+/**
+ * Breakpoint keys.
+ *
+ * Used in responsive spacing and grid settings, and calculating breakpoint boundaries
+ */
+export type FudisBreakpointKey = 'default' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';

--- a/ngx-fudis/projects/ngx-fudis/src/lib/types/breakpoints.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/types/breakpoints.ts
@@ -1,3 +1,4 @@
+import { FudisBreakpointKey } from './breakpoint-keys';
 import { FudisSpacing } from './spacing';
 
 type FudisBreakpointsMinWidths = {
@@ -58,11 +59,6 @@ export interface FudisBreakpointStyleResponsive {
 export type FudisBreakpointValueResponsive = {
   [key in FudisBreakpointKey]?: FudisSpacing | string | number;
 };
-
-/**
- * Breakpoint keys to watch
- */
-export type FudisBreakpointKey = 'default' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 
 export type FudisBreakpointBoundary =
   | '(min-width: 100em)'

--- a/ngx-fudis/projects/ngx-fudis/src/lib/types/grid.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/types/grid.ts
@@ -1,4 +1,5 @@
-import { FudisBreakpointKey, FudisBreakpointValueResponsive } from './breakpoints';
+import { FudisBreakpointKey } from './breakpoint-keys';
+import { FudisBreakpointValueResponsive } from './breakpoints';
 import { FudisSpacing } from './spacing';
 
 // --------------------

--- a/ngx-fudis/projects/ngx-fudis/src/lib/types/spacing.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/types/spacing.ts
@@ -1,4 +1,4 @@
-import { FudisBreakpointKey } from './breakpoints';
+import { FudisBreakpointKey } from './breakpoint-keys';
 
 export const fudisSpacingArray = ['none', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl'] as const;
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/types/types.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/types/types.ts
@@ -1,4 +1,5 @@
 export * from './breakpoints';
+export * from './breakpoint-keys';
 export * from './errorSummary';
 export * from './forms';
 export * from './grid';

--- a/ngx-fudis/projects/ngx-fudis/src/lib/utilities/breakpoint/breakpoint-utils.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/utilities/breakpoint/breakpoint-utils.ts
@@ -1,6 +1,6 @@
 import { getGridCssValue } from '../../directives/grid/gridUtils';
+import { FudisBreakpointKey } from '../../types/breakpoint-keys';
 import {
-  FudisBreakpointKey,
   FudisBreakpointStyleResponsive,
   FudisBreakpointValueResponsive,
   fudisBreakpointsMinWidth,


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-508

Files affected by circular dependency:
- `button.component.ts` > `dropdown-menu.component.ts`
  - Created shared `dropdown-event.service.ts`
  - Dropdown element's width calculation has to be triggered by click coming from ButtonComponent
    - DropdownMenu subscribes to the triggering observable
  - DropdownMenu can again use parent ButtonComponent through `@Host()` decorator as before (without forwardRef injection that was earlier made as a hotfix)
- `breakpoints.ts` > `spacing.ts`
  - These were type-only imports causing circularity
  - Moved `FudisBreakpointKey` type to a separate file `breakpoint-keys.ts`
- `multiselect.component.ts` > `select-base.directive.ts` & `select-base.directive.ts` > `select.component.ts`
  - SelectBase needs to listen to some component changes from Select and Multiselect
    - Created shared interface `base-selectable.interface.ts` with generic typing and necessary properties for SelectBase to be able to use it without importing Select and Multiselect
    - Added the interface implementation to Select and Multiselect