### PR TITLE
[MultiSelectOption]: Identical option label

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/mock_data.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/common/mock_data.ts
@@ -22,9 +22,19 @@ export const defaultOptions: FudisSelectOption<TestAnimalSound>[] = [
   { value: 'value-3-platypys', label: 'Platypus', sound: 'Plat plat!' },
   { value: 'value-4-cat', label: 'Really dangerous cat', disabled: true, sound: 'PurrROAR!' },
   {
+    value: { name: 'value-duplicate-1', breed: 'Unwanted' },
+    label: 'Sadly I am an unwanted duplicate',
+    sound: 'Nooooo!',
+  },
+  {
     value: 'value-5-armadillo_(PARTLY_ENDANGERED)',
     label: 'Screaming hairy armadillo (partly endangered)',
     sound: "Rollin' rollin' rollin'!",
+  },
+  {
+    value: { name: 'value-duplicate-2', breed: 'Unwanted' },
+    label: 'Sadly I am an unwanted duplicate',
+    sound: 'Nooooo!',
   },
   { value: 'value-6-gecko', label: 'Southern Titiwangsa Bent-Toed Gecko', sound: 'Gec-koooo!' },
 ];

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect-option/multiselect-option.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect-option/multiselect-option.component.html
@@ -8,7 +8,7 @@
   [class.fudis-multiselect-option--disabled]="data.disabled"
 >
   <label
-    [attr.for]="_id + '-checkbox-input'"
+    [attr.for]="_id + '-checkbox-input-' + componentInstanceId"
     class="fudis-multiselect-option__label"
     [class.fudis-multiselect-option__label--focus]="_focused"
     [class.fudis-multiselect-option__label--checked]="checked"
@@ -23,7 +23,7 @@
         type="checkbox"
         class="fudis-multiselect-option__label__checkbox__input"
         role="option"
-        [attr.id]="_id + '-checkbox-input'"
+        [attr.id]="_id + '-checkbox-input-' + componentInstanceId"
         [attr.aria-disabled]="data.disabled || null"
         (click)="!data.disabled && _clickOption($event)"
         [attr.aria-selected]="checked"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect-option/multiselect-option.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/select/multiselect/multiselect-option/multiselect-option.component.ts
@@ -19,6 +19,9 @@ export class MultiselectOptionComponent
   extends SelectOptionBaseDirective
   implements OnDestroy, OnChanges
 {
+  private static instanceCounter = 0;
+  protected readonly componentInstanceId: string;
+
   constructor(
     @Inject(DOCUMENT) _document: Document,
     @Host() protected _parentMultiselect: MultiselectComponent,
@@ -27,6 +30,9 @@ export class MultiselectOptionComponent
     _translationService: FudisTranslationService,
   ) {
     super(_document, _parentGroup, _translationService, _idService);
+
+    MultiselectOptionComponent.instanceCounter++;
+    this.componentInstanceId = MultiselectOptionComponent.instanceCounter.toString();
 
     this._parent = this._parentMultiselect;
 

--- a/test/visual-regression/multiselect.spec.ts
+++ b/test/visual-regression/multiselect.spec.ts
@@ -24,7 +24,9 @@ test("Dropdown with Clear Button and dropdown keyboard interactions", async ({ p
   await page.keyboard.press("ArrowDown");
   await page.keyboard.press("ArrowDown"); /* Focus is on disabled option */
   await page.keyboard.press("ArrowDown");
-  await expect(page.getByTestId("fudis-multiselect-1-option-100zewl-checkbox-input")).toBeFocused();
+  await expect(
+    page.getByTestId("fudis-multiselect-1-option-100zewl-checkbox-input-6"),
+  ).toBeFocused();
   await page.keyboard.press("ArrowUp");
   await page.keyboard.press("ArrowUp");
   await page.keyboard.press("ArrowUp");
@@ -34,7 +36,9 @@ test("Dropdown with Clear Button and dropdown keyboard interactions", async ({ p
   await page.keyboard.press("ArrowUp");
   await page.keyboard.press("ArrowUp");
 
-  await expect(page.getByTestId("fudis-multiselect-1-option-nr48pp-checkbox-input")).toBeFocused();
+  await expect(
+    page.getByTestId("fudis-multiselect-1-option-nr48pp-checkbox-input-55"),
+  ).toBeFocused();
   await page.getByTestId("fudis-multiselect-1-option-ibd9lw").hover();
   await expect(page).toHaveScreenshot("A-4-hover-alligator.png", {
     fullPage: true,
@@ -200,7 +204,7 @@ test("Dropdown and autocompletes", async ({ page }) => {
   await page.keyboard.press("ArrowDown");
   await page.keyboard.press("ArrowDown");
   await expect(
-    page.getByTestId("fudis-multiselect-5-option-1fkgm3k-checkbox-input"),
+    page.getByTestId("fudis-multiselect-5-option-1fkgm3k-checkbox-input-40"),
   ).toBeInViewport();
   await page.keyboard.press("Space");
   await page.getByTestId("fudis-heading-1").hover();
@@ -232,4 +236,47 @@ test("Dropdown and autocompletes", async ({ page }) => {
   await page.keyboard.press("Backspace");
   await page.keyboard.press("Backspace");
   await expect(page.getByTestId("fudis-multiselect-6-dropdown")).not.toBeVisible();
+});
+
+test("Select values that have duplicate labels", async ({ page }) => {
+  await page.goto(
+    "/iframe.html?globals=&args=&id=components-form-select-multiselect--example&viewMode=story",
+  );
+
+  await page.getByTestId("fudis-multiselect-1").click();
+  await expect(page.getByTestId("fudis-multiselect-1-dropdown")).toBeVisible();
+  await expect(
+    page.getByTestId("fudis-multiselect-1-option-hxx4g6-checkbox-input-7"),
+  ).toHaveAttribute("aria-selected", "false");
+
+  await page
+    .getByTestId("fudis-multiselect-1-dropdown")
+    .getByText("Sadly I am an unwanted duplicate")
+    .nth(1)
+    .click();
+
+  await expect(
+    page.getByTestId("fudis-multiselect-1-option-hxx4g6-checkbox-input-7"),
+  ).toHaveAttribute("aria-selected", "true");
+  await expect(
+    page.getByTestId("fudis-multiselect-1-option-hxx4g6-checkbox-input-5"),
+  ).toHaveAttribute("aria-selected", "false");
+
+  await page
+    .getByTestId("fudis-multiselect-1-dropdown")
+    .getByText("Sadly I am an unwanted duplicate")
+    .nth(1)
+    .click();
+  await page
+    .getByTestId("fudis-multiselect-1-dropdown")
+    .getByText("Sadly I am an unwanted duplicate")
+    .nth(0)
+    .click();
+
+  await expect(
+    page.getByTestId("fudis-multiselect-1-option-hxx4g6-checkbox-input-7"),
+  ).toHaveAttribute("aria-selected", "false");
+  await expect(
+    page.getByTestId("fudis-multiselect-1-option-hxx4g6-checkbox-input-5"),
+  ).toHaveAttribute("aria-selected", "true");
 });


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-527

As the library is generating the element id's independently, it is causing issues when the consuming application passes unexpected data, like options with duplicated labels. This however should be expected and the library should work flawlessly in these cases as well. This is now not the case and the probably the only way to truly solve this issue, would mean getting rid of the id-service and leave the id's to the using application, not the library. This needs to be discussed though and it would require a lot of work, so did a quick fix to multiselectoption. Before the id's were created by using raw labels, that was causing a lot of issues. I did a quick fix in jan/feb, where I hashed the id's so the special characters would not cause issues. This did not remove the original problem of duplicate id's, when the labels are identical. 

This pr contains another hack, that creates a running id by using a static counter that is incremented when new instance of multiselect option is created. This component was the only one having issues in use, so that is the reason why it is the only component where this fix was implemented. **This does not mean that the duplicate id's won't cause any issues in other components, so this should be fixed asap.**