### PR TITLE
Create redirect objects in /ngx child paths when publishing docs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,3 +113,5 @@ jobs:
           </head>
           </html>" > /tmp/index.html
           aws s3 cp /tmp/index.html s3://${{ secrets.AWS_S3_BUCKET_NAME }}/ngx --cache-control max-age=5
+          aws s3 cp /tmp/index.html s3://${{ secrets.AWS_S3_BUCKET_NAME }}/ngx/index.html --cache-control max-age=5
+          aws s3 cp /tmp/index.html s3://${{ secrets.AWS_S3_BUCKET_NAME }}/ngx/v/index.html --cache-control max-age=5


### PR DESCRIPTION
https://funidata.atlassian.net/browse/INFRA-1753

This change fixes URL's fudis.funidata.fi/ngx/ and fudis.funidata.fi/ngx/v/ which currently do not redirect to latest docs but rather return HTTP 403.