### PR TITLE
Run VR tests in parallel to reduce CI run duration

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,5 +1,8 @@
 name: Run tests
 
+permissions:
+  contents: read
+
 on:
   # Enable reusing this workflow.
   workflow_call:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -121,6 +121,11 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -149,7 +154,8 @@ jobs:
             --network=host \
             --mount type=bind,source=./test/test-results,target=/usr/src/app/test-results \
             --mount type=bind,source=./test/playwright-report,target=/usr/src/app/playwright-report \
-            fudis-pw
+            fudis-pw \
+            npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -145,7 +145,7 @@ jobs:
       - name: Wait for Storybook server to be up
         run: curl --head -X GET --retry 10 --retry-connrefused --retry-delay 5 http://localhost:6006
       - name: Create test output directories for mounts
-        run: mkdir test/test-results test/playwright-report
+        run: mkdir test/test-results test/playwright-report test/blob-report
       - name: Run visual regression tests
         run: |
           docker run -t \
@@ -154,17 +154,46 @@ jobs:
             --network=host \
             --mount type=bind,source=./test/test-results,target=/usr/src/app/test-results \
             --mount type=bind,source=./test/playwright-report,target=/usr/src/app/playwright-report \
+            --mount type=bind,source=./test/blob-report,target=/usr/src/app/blob-report \
             fudis-pw \
             npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
-      - uses: actions/upload-artifact@v4
-        if: always()
+      - name: Upload blob report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
         with:
-          name: playwright-report
-          path: test/playwright-report/
-          retention-days: 7
-      - uses: actions/upload-artifact@v4
-        if: failure()
+          name: blob-report-${{ matrix.shardIndex }}
+          path: test/blob-report/
+          retention-days: 1
+
+  # Combine blob reports from matrix shards into a single Playwright report.
+  playwright-report:
+    name: VR test report
+    runs-on: ubuntu-22.04
+    needs:
+      - visual-regression-tests
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          name: test-results
-          path: test/test-results/
+          node-version-file: .nvmrc
+      - name: Install dependencies
+        run: npm ci
+        working-directory: test
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          path: test/all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+      - name: Merge into HTML Report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+        working-directory: test
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-report--attempt-${{ github.run_attempt }}
+          path: test/playwright-report
           retention-days: 7

--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -11,9 +11,9 @@ export default defineConfig({
   /* Retry on CI only */
   retries: ci ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: ci || process.env.CONTAINER ? 1 : undefined,
+  workers: process.env.CONTAINER ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [["html", { host: "0.0.0.0" }]],
+  reporter: ci ? "blob" : [["html", { host: "0.0.0.0" }]],
   /* Threshold to wait action to complete */
   timeout: 15000,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -1,15 +1,17 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const ci = process.env.CI === "true";
+
 export default defineConfig({
   testDir: "./visual-regression",
   /* Run tests __in files__ in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
+  forbidOnly: ci,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: ci ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI || process.env.CONTAINER ? 1 : undefined,
+  workers: ci || process.env.CONTAINER ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [["html", { host: "0.0.0.0" }]],
   /* Threshold to wait action to complete */


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-523

This PR modifies the Playwright test setup so that the tests are run in parallel in CI. This does not affect running tests locally. I use GitHub's matrix strategy and Playwrights sharding feature to split the tests into four groups and run them on different workflow runners. After the shards have completed, I combine the shard-specific blob reports into a single report.

> [!NOTE]
> Branch protection settings must be updated to require the new tests before a PR is merged. (The test names change and there is now one test per shard.)

> [!TIP]
> The blob reports are JSON and not nicely readable. When a shard fails, it's easier to wait until the combined report has been generated.