### PR TITLE
[Github Actions]: Change wildcard pattern for dependabot branches

### DIFF
--- a/.github/workflows/publish_docs_from_pr.yaml
+++ b/.github/workflows/publish_docs_from_pr.yaml
@@ -8,7 +8,7 @@ on:
     branches-ignore:
       - main
       - "release-**"
-      - "dependabot/*"
+      - "dependabot/**"
 
 jobs:
   publish:


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-555

We want to disable publishing documentation from branches created by dependabot.

`dependabot/**` instead of `dependabot/*` will probably better match all the possible branch names that dependabot will create, e.g. `dependabot/npm_and_yarn/ngx-fudis/babel-53c6152798`.