### PR TITLE
[ErrorSummary]: Submit attempt signal

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.ts
@@ -35,7 +35,13 @@ export class ErrorSummaryComponent implements AfterViewInit, OnInit {
   constructor(
     private _errorSummaryService: FudisInternalErrorSummaryService,
     protected _translationService: FudisTranslationService,
-  ) {}
+  ) {
+    toObservable(this._errorSummaryService.submitAttempt, { injector: this._injector }).subscribe(
+      () => {
+        this._focusToErrorSummary();
+      },
+    );
+  }
 
   @ViewChild('focusTarget') private _focusTarget: NotificationComponent;
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/internal-error-summary.service.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/internal-error-summary.service.ts
@@ -84,6 +84,11 @@ export class FudisInternalErrorSummaryService implements OnDestroy {
    */
   private _reloadGuard: string[] = [];
 
+  /**
+   * Signal for counting submit attempts
+   */
+  private _submitAttempt = signal(0);
+
   // --------------------
   //
   // GETTERS & SETTERS FOR CLASS VARIABLES
@@ -109,6 +114,13 @@ export class FudisInternalErrorSummaryService implements OnDestroy {
    */
   get errorsSignal(): FudisErrorSummaryAllErrorsSignal {
     return this._errorsSignal;
+  }
+
+  /**
+   * Used for firing focus to error summary when submitting
+   */
+  get submitAttempt() {
+    return this._submitAttempt;
   }
 
   /**
@@ -253,6 +265,7 @@ export class FudisInternalErrorSummaryService implements OnDestroy {
   public reloadFormErrors(formId: string, focus?: boolean): void {
     if (focus) {
       this._focusToFormOnReload = formId;
+      this._submitAttempt.update((submitCount) => submitCount + 1);
     } else {
       this._focusToFormOnReload = null;
     }


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-495

Focus wasn't moving to error summary when firing submit buttons with errors. This was cause of a FudisErrorSummaryAllErrorsSignal which wasn't updating with new errors. Now created a new signal that will always fire when reloadFormErrors are triggered and will move focus to error summary when present.