### PR TITLE
[Dependencies]: Update prettier and prettier-plugin-jsdoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "hasInstallScript": true,
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
-        "prettier-plugin-jsdoc": "^1.3.2"
+        "prettier-plugin-jsdoc": "^1.3.3"
       },
       "devDependencies": {
-        "prettier": "^3.4.2"
+        "prettier": "^3.6.2"
       }
     },
     "node_modules/@types/debug": {
@@ -609,9 +609,9 @@
       "license": "MIT"
     },
     "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -624,9 +624,9 @@
       }
     },
     "node_modules/prettier-plugin-jsdoc": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-1.3.2.tgz",
-      "integrity": "sha512-LNi9eq0TjyZn/PUNf/SYQxxUvGg5FLK4alEbi3i/S+2JbMyTu790c/puFueXzx09KP44oWCJ+TaHRyM/a0rKJQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-1.3.3.tgz",
+      "integrity": "sha512-YIxejcbPYK4N58jHGiXjYvrCzBMyvV2AEMSoF5LvqqeMEI0nsmww57I6NGnpVc0AU9ncFCTEBoYHN/xuBf80YA==",
       "license": "MIT",
       "dependencies": {
         "binary-searching": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   "author": "Funidata Ltd",
   "license": "CC-BY-NC-SA-4.0",
   "devDependencies": {
-    "prettier": "^3.4.2"
+    "prettier": "^3.6.2"
   },
   "dependencies": {
-    "prettier-plugin-jsdoc": "^1.3.2"
+    "prettier-plugin-jsdoc": "^1.3.3"
   }
 }


### PR DESCRIPTION
Dependabot was trying to update `prettier` (in this PR: https://github.com/funidata/fudis/pull/680) but it failed to update `prettier-plugin-jsdoc` as well, so it caused formatting to break.