### PR TITLE
[GithubActions]: Update upload-artifact and download-artifact

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -19,7 +19,7 @@ jobs:
           tags: fudis-test
           outputs: type=docker,dest=/tmp/fudis-test.image.tar
       - name: Save image as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: fudis-test
           path: /tmp/fudis-test.image.tar

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: fudis-test
           path: /tmp
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: fudis-test
           path: /tmp
@@ -90,7 +90,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: fudis-test
           path: /tmp
@@ -105,7 +105,7 @@ jobs:
             --mount type=bind,source=./coverage,target=/usr/src/app/projects/ngx-fudis/coverage \
             fudis-test npm test
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage
           path: coverage
@@ -135,7 +135,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: fudis-test
           path: /tmp
@@ -161,7 +161,7 @@ jobs:
             fudis-pw \
             npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: Upload blob report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: ${{ !cancelled() }}
         with:
           name: blob-report-${{ matrix.shardIndex }}
@@ -186,7 +186,7 @@ jobs:
         run: npm ci
         working-directory: test
       - name: Download blob reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: test/all-blob-reports
           pattern: blob-report-*
@@ -195,7 +195,7 @@ jobs:
         run: npx playwright merge-reports --reporter html ./all-blob-reports
         working-directory: test
       - name: Upload HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: e2e-test-report--attempt-${{ github.run_attempt }}
           path: test/playwright-report


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-574

Update from `actions/download-artifact@v4` and `actions/upload-artifact@v4` to `actions/download-artifact@v5` and `actions/upload-artifact@v5`

> Use matching versions of actions/upload-artifact and actions/download-artifact to ensure compatibility.

https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md