### PR TITLE
[GithubActions]: Log output for failed vr job

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -141,10 +141,8 @@ jobs:
           path: /tmp
       - name: Load image
         run: docker load --input /tmp/fudis-test.image.tar
-      - name: Set container name
-        run: echo "CONTAINER_NAME=fudis-vr-test-${{ github.run_id }}" >> $GITHUB_ENV
       - name: Start Storybook
-        run: docker run --name $CONTAINER_NAME -d -p 6006:6006 fudis-test npm run storybook
+        run: docker run --name fudis-vr-test -d -p 6006:6006 fudis-test npm run storybook
       - name: Build Playwright image
         run: docker build -t fudis-pw test/
       - name: Wait for Storybook server to be up
@@ -173,7 +171,7 @@ jobs:
         if: failure()
         run: |
           docker ps
-          docker logs $CONTAINER_NAME
+          docker logs fudis-vr-test
 
   # Combine blob reports from matrix shards into a single Playwright report.
   playwright-report:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -141,12 +141,14 @@ jobs:
           path: /tmp
       - name: Load image
         run: docker load --input /tmp/fudis-test.image.tar
+      - name: Set container name
+        run: echo "CONTAINER_NAME=fudis-vr-test-${{ github.run_id }}" >> $GITHUB_ENV
       - name: Start Storybook
-        run: docker run -d -p 6006:6006 fudis-test npm run storybook
+        run: docker run --name $CONTAINER_NAME -d -p 6006:6006 fudis-test npm run storybook
       - name: Build Playwright image
         run: docker build -t fudis-pw test/
       - name: Wait for Storybook server to be up
-        run: curl --head -X GET --retry 10 --retry-connrefused --retry-delay 5 http://localhost:6006
+        run: curl --head -X GET --retry 10 --retry-all-errors --retry-delay 5 http://localhost:6006
       - name: Create test output directories for mounts
         run: mkdir test/test-results test/playwright-report test/blob-report
       - name: Run visual regression tests
@@ -167,6 +169,11 @@ jobs:
           name: blob-report-${{ matrix.shardIndex }}
           path: test/blob-report/
           retention-days: 1
+      - name: Print debug output
+        if: failure()
+        run: |
+          docker ps
+          docker logs $CONTAINER_NAME
 
   # Combine blob reports from matrix shards into a single Playwright report.
   playwright-report:


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-574

- Added suggested log output for visual-regression-test job
  - Log only when failure occurs
- Add hard-coded container name, otherwise it will have randomized name and cannot be called by `docker logs`