### PR TITLE
[Grid, GridItem] Change Grid and GridItem to use OnPush

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid-item/grid-item.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid-item/grid-item.component.ts
@@ -11,6 +11,6 @@ import { GridItemDirective } from '../../../directives/grid/grid-item/grid-item.
   templateUrl: './grid-item.component.html',
   styleUrls: ['./grid-item.component.scss'],
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GridItemComponent extends GridItemDirective {}

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid-item/grid-item.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid-item/grid-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
 import { GridItemDirective } from '../../../directives/grid/grid-item/grid-item.directive';
 
 /**
@@ -11,5 +11,6 @@ import { GridItemDirective } from '../../../directives/grid/grid-item/grid-item.
   templateUrl: './grid-item.component.html',
   styleUrls: ['./grid-item.component.scss'],
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class GridItemComponent extends GridItemDirective {}

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid/grid.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid/grid.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
 import { GridDirective } from '../../../directives/grid/grid/grid.directive';
 
 /**
@@ -11,6 +11,7 @@ import { GridDirective } from '../../../directives/grid/grid/grid.directive';
   templateUrl: './grid.component.html',
   styleUrls: ['./grid.component.scss'],
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 
 /**

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid/grid.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid/grid.component.ts
@@ -11,7 +11,7 @@ import { GridDirective } from '../../../directives/grid/grid/grid.directive';
   templateUrl: './grid.component.html',
   styleUrls: ['./grid.component.scss'],
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 
 /**


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-387

These two components are changed to OnPush with minimal changes like the previous ones. 

- The logic for both components are in the directive files, and these directives use ngOnChanges and effect(), which should be unaffected by OnPush. 
- Both components use only <ng-content> in the template, so there is no need to re-render anything.

  
### Developer's checklist
- [ ] I wrote necessary unit tests
- [ ] I updated Storybook stories and documentation to reflect the latest changes
- [ ] I included visual regression tests for new UI design
- [ ] I tested my implementation with different browsers
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
- [ ] Together with the reviewer I can confirm that the implementation supports the following screenreader and browser combinations (NVDA + Firefox, VoiceOver + Chrome)
