### PR TITLE
[Pagination]: Add !important flags to necessary style overrides

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/pagination/pagination.component.scss
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/pagination/pagination.component.scss
@@ -10,9 +10,11 @@ fudis-pagination {
   padding-top: core.$spacing-lg;
 
   &-button {
-    // Override default button styles from Core
-    padding-top: 0;
-    padding-bottom: 0;
+    // Override default button styles from Core. These need !important flags in order to work properly in consuming app side.
+    /* stylelint-disable-next-line declaration-no-important */
+    padding-top: 0 !important;
+    /* stylelint-disable-next-line declaration-no-important */
+    padding-bottom: 0 !important;
 
     &__previous {
       margin-right: core.$spacing-xs;


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-659

Noticed that the previous padding overrides were not working in consuming app side.
- Fixed by adding `!important` flags
- Previous PR https://github.com/funidata/fudis/pull/849

Tested the change in consuming app with tarball:
<img width="684" height="128" alt="Screenshot 2026-04-10 at 10 53 19" src="https://github.com/user-attachments/assets/235cf163-16c3-4c10-88ac-fd4082b894a5" />
<img width="631" height="120" alt="Screenshot 2026-04-10 at 10 58 33" src="https://github.com/user-attachments/assets/f12928df-8af1-487a-87d7-500ea6f390d1" />



  
### Developer's checklist
- [ ] I wrote necessary unit tests
- [ ] I updated Storybook stories and documentation to reflect the latest changes
- [ ] I included visual regression tests for new UI design
- [ ] I tested my implementation with different browsers
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
- [ ] Together with the reviewer I can confirm that the implementation supports the following screenreader and browser combinations (NVDA + Firefox, VoiceOver + Chrome)
