### PR TITLE
[Expandable]: Convert to OnPush

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.component.html
@@ -2,7 +2,7 @@
   [id]="_id"
   [attr.aria-labelledby]="_headingId"
   class="fudis-expandable fudis-expandable__{{ variant }}"
-  [class.fudis-expandable--closed]="_closed"
+  [class.fudis-expandable--closed]="_closed()"
 >
   <div class="fudis-expandable__header fudis-expandable__header__{{ variant }}">
     <div
@@ -17,9 +17,9 @@
         class="fudis-expandable__header__heading__button fudis-expandable__header__heading__button__{{
           variant
         }}"
-        [attr.aria-expanded]="!_closed"
+        [attr.aria-expanded]="!_closed()"
         [attr.aria-controls]="!closed ? _id + '__content' : null"
-        (click)="_setClosedStatus(!_closed)"
+        (click)="_setClosedStatus(!_closed())"
       >
         <fudis-icon
           class="fudis-expandable__header__heading__button__icon fudis-expandable__header__heading__button__icon__{{
@@ -27,7 +27,7 @@
           }}"
           [icon]="variant === 'lite' ? 'chevron' : 'chevron-ring-fill'"
           [color]="variant === 'lite' ? 'primary' : 'gray-dark'"
-          [rotate]="_closed ? 'none' : 'cw-90'"
+          [rotate]="_closed() ? 'none' : 'cw-90'"
         ></fudis-icon
         ><span class="fudis-expandable__header__heading__button__title"
           ><span class="fudis-expandable__header__heading__button__title__text">{{ title }}</span>
@@ -48,12 +48,12 @@
     </div>
     <ng-content select="fudis-expandable-actions" />
   </div>
-  @if (_openedOnce) {
+  @if (_openedOnce()) {
     <div
       class="fudis-expandable__content fudis-expandable__content__padding-{{ padding }}"
       [id]="_id + '__content'"
-      [attr.aria-hidden]="_closed"
-      [hidden]="_closed"
+      [attr.aria-hidden]="_closed()"
+      [hidden]="_closed()"
     >
       @if (_content) {
         <ng-container *ngTemplateOutlet="_content!.templateRef"></ng-container>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.component.html
@@ -18,7 +18,7 @@
           variant
         }}"
         [attr.aria-expanded]="!_closed()"
-        [attr.aria-controls]="!closed ? _id + '__content' : null"
+        [attr.aria-controls]="!_closed() ? _id + '__content' : null"
         (click)="_setClosedStatus(!_closed())"
       >
         <fudis-icon

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.component.spec.ts
@@ -355,7 +355,7 @@ describe('ExpandableComponent', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(ExpandableComponent);
       component = fixture.componentInstance;
-      component.title = 'Test title';
+      fixture.componentRef.setInput('title', 'Test title');
       fixture.detectChanges();
     });
 
@@ -367,10 +367,10 @@ describe('ExpandableComponent', () => {
 
     it('should have title level', () => {
       fudisHeadingLevelArray.forEach((level) => {
-        component.level = level;
+        fixture.componentRef.setInput('level', `${level}`);
         fixture.detectChanges();
 
-        const heading = getElement(fixture, '.fudis-expandable .fudis-expandable__header__heading');
+        const heading = getElement(fixture, '.fudis-expandable__header__heading');
 
         expect(heading.getAttribute('aria-level')).toEqual(`${level}`);
       });

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.component.ts
@@ -11,6 +11,9 @@ import {
   inject,
   Injector,
   AfterContentInit,
+  ChangeDetectionStrategy,
+  WritableSignal,
+  signal,
 } from '@angular/core';
 import {
   FudisBadgeVariant,
@@ -35,6 +38,7 @@ import { NgTemplateOutlet } from '@angular/common';
   templateUrl: './expandable.component.html',
   styleUrls: ['./expandable.component.scss'],
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [IconComponent, BadgeComponent, NgTemplateOutlet],
 })
 export class ExpandableComponent implements OnDestroy, OnChanges, AfterContentInit {
@@ -114,7 +118,7 @@ export class ExpandableComponent implements OnDestroy, OnChanges, AfterContentIn
   /**
    * Internal boolean of whether the expandable is currently closed
    */
-  protected _closed: boolean = true;
+  protected _closed: WritableSignal<boolean> = signal(true);
 
   /**
    * Internal id to generate unique id
@@ -129,7 +133,7 @@ export class ExpandableComponent implements OnDestroy, OnChanges, AfterContentIn
   /**
    * Lazy loading check for expanding content
    */
-  protected _openedOnce: boolean = false;
+  protected _openedOnce: WritableSignal<boolean> = signal(false);
 
   /**
    * Is info sent to Error Summary Service
@@ -163,7 +167,7 @@ export class ExpandableComponent implements OnDestroy, OnChanges, AfterContentIn
    * Getter for closed boolean
    */
   get closed(): boolean {
-    return this._closed;
+    return this._closed();
   }
 
   private _injector = inject(Injector);
@@ -214,8 +218,8 @@ export class ExpandableComponent implements OnDestroy, OnChanges, AfterContentIn
    * Setter for closed boolean
    */
   protected _setClosedStatus(value: boolean): void {
-    this._closed = value ?? this._closed;
-    this._openedOnce = this._openedOnce || !this._closed;
-    this.closedChange.emit(this._closed);
+    this._closed.set(value ?? this._closed());
+    this._openedOnce.set(this._openedOnce() || !this._closed());
+    this.closedChange.emit(this._closed());
   }
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.component.ts
@@ -99,8 +99,9 @@ export class ExpandableComponent implements OnDestroy, OnChanges, AfterContentIn
 
   // TODO: write test
   /**
-   * If Expandable is used inside Form component, by default it will open itself when ReloadErrors
-   * is called in Error Summary Service. To disable this behavior, set this to false.
+   * If Expandable is used inside Form component, by default it will open itself when
+   * reloadFormErrors is called in Error Summary Service. To disable this behavior, set this to
+   * false.
    */
   @Input() openOnErrorSummaryReload: boolean = true;
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.component.ts
@@ -8,6 +8,7 @@ import {
   OnDestroy,
   OnChanges,
   ElementRef,
+  DestroyRef,
   inject,
   Injector,
   AfterContentInit,
@@ -22,7 +23,7 @@ import {
 } from '../../types/miscellaneous';
 import { FudisIdService } from '../../services/id/id.service';
 import { FudisInternalErrorSummaryService } from '../../services/form/error-summary/internal-error-summary.service';
-import { toObservable } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ExpandableContentDirective } from './expandable-content.directive';
 import { IconComponent } from '../icon/icon.component';
 import { BadgeComponent } from '../badge/badge.component';
@@ -142,24 +143,29 @@ export class ExpandableComponent implements OnDestroy, OnChanges, AfterContentIn
 
   private _parentFormId: string | null;
 
+  private _destroyRef = inject(DestroyRef);
+
   private _getParentForm(): void {
     this._errorSummaryService
       .getFormAncestorId(this._element.nativeElement)
       .then((parentFormId) => {
-        if (parentFormId) {
-          this._parentFormId = parentFormId;
-          if (this.errorSummaryBreadcrumb) {
-            this._addToErrorSummary(this.title);
-          }
+        if (!parentFormId) return;
 
-          toObservable(this._errorSummaryService.errorSummaryVisibilityStatus[this._parentFormId], {
-            injector: this._injector,
-          }).subscribe((value) => {
+        this._parentFormId = parentFormId;
+
+        if (this.errorSummaryBreadcrumb) {
+          this._addToErrorSummary(this.title);
+        }
+
+        toObservable(this._errorSummaryService.errorSummaryVisibilityStatus[this._parentFormId], {
+          injector: this._injector,
+        })
+          .pipe(takeUntilDestroyed(this._destroyRef))
+          .subscribe((value) => {
             if (this.closed && this.openOnErrorSummaryReload && value) {
               this._setClosedStatus(false);
             }
           });
-        }
       });
   }
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/expandable/expandable.mdx
@@ -10,6 +10,15 @@ import * as VersionSelectorStories from "../../../storybook-docs/version-selecto
 
 Fudis Expandable is an accordion component where its content can be expanded or collapsed to create more compact pages.
 
+**Table of Contents:**
+
+- [Commonly Used Properties](#commonly-used-properties)
+- [Content Projection](#content-projection)
+- [Examples](#examples)
+- [Expandable as Form's Child Component](#expandable-as-forms-child-component)
+- [Accessibility](#accessibility)
+- [Properties](#properties)
+
 ## Commonly Used Properties
 
 ### Variant
@@ -59,7 +68,7 @@ If Expandable has any form field components, e. g. Text Input as its child conte
 
 This can cause syncing issues with Form and Error Summary, because Text Input and other form field components send data to Error Summary only after they are loaded to the DOM.
 
-To ease this issue, property `openOnErrorSummaryReload` is by default `true`: If Expandable is a child component of [Form Component](/docs/components-form-form--documentation), the Expandable will open itself whenever [Error Summary Service's reloadErrors()](/docs/services-error-summary--documentation#reload-errors) is called.
+To ease this issue, property `openOnErrorSummaryReload` is by default `true`: If Expandable is a child component of [Form Component](/docs/components-form-form--documentation), the Expandable will open itself whenever [Error Summary Service's reloadFormErrors()](/docs/services-error-summary--documentation#reloadformerrors) is called.
 
 ### Property `errorSummaryBreadcrumb`
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/error-summary/error-summary.component.ts
@@ -210,7 +210,7 @@ export class ErrorSummaryComponent implements AfterViewInit, OnInit {
 
   ngOnInit(): void {
     /**
-     * Fetch and update current visible errors when reloadErrors() is called
+     * Fetch and update current visible errors when reloadFormErrors() is called
      */
     toObservable(this._errorSummaryService.errorsSignal[this.formId], {
       injector: this._injector,

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/form-actions/form-actions.directive.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/form-actions/form-actions.directive.ts
@@ -24,9 +24,9 @@ export class FormSubmitDirective implements OnInit {
   ) {}
 
   /**
-   * If false, Button will set parent Form's 'errorSummaryVisible' to true and call reloadErrors()
-   * from Error Summary Service If true, Button will set parent Form's 'errorSummaryVisible' to
-   * false
+   * If false, Button will set parent Form's 'errorSummaryVisible' to true and call
+   * reloadFormErrors() from Error Summary Service If true, Button will set parent Form's
+   * 'errorSummaryVisible' to false
    */
   @Input() formValid: boolean = false;
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/error-summary.service.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/error-summary.service.ts
@@ -69,7 +69,7 @@ export class FudisErrorSummaryService {
   // TODO: This should be removed and replaced with getter for collection of Signals per individual Forms
   /**
    * Returns an observable of all errors sent to Error Summary. Note, that Observable is updated
-   * only when ReloadErrors is called.
+   * only when reloadFormErrors is called.
    */
   public getErrorsObservable(): BehaviorSubject<FudisErrorSummaryAllErrors> {
     return this._errorSummaryService.errorsObservable;

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/internal-error-summary.service.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/internal-error-summary.service.ts
@@ -47,13 +47,13 @@ export class FudisInternalErrorSummaryService implements OnDestroy {
 
   /**
    * Collection of all registered errors categorised by parent Form id. Used as "temporary" storage
-   * and value will be passed to Observable when ReloadErrors is called.
+   * and value will be passed to Observable when reloadFormErrors is called.
    */
   private _errorsStore: FudisErrorSummaryAllErrors = {};
 
   /**
    * Collection of all registered errors categorised by parent Form id. This Observable is updated
-   * with new value only when ReloadErrors is called.
+   * with new value only when reloadFormErrors is called.
    */
   private _errorsObservable = new BehaviorSubject<FudisErrorSummaryAllErrors>({});
 


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-374

Converting Expandable component to OnPush
- Updated internal `_closed` and `_openedOnce` to signals
- Added explicit lifecycle for subscription with `DestroyRef`
- Added guard against late resolve of the Promise
  
### Developer's checklist
- [ ] I wrote necessary unit tests
- [ ] I updated Storybook stories and documentation to reflect the latest changes
- [ ] I included visual regression tests for new UI design
- [ ] I tested my implementation with different browsers
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
- [ ] Together with the reviewer I can confirm that the implementation supports the following screenreader and browser combinations (NVDA + Firefox, VoiceOver + Chrome)
