### PR TITLE
[RadioButton, RadioButtonGroup]: Convert to OnPush

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.spec.ts
@@ -127,7 +127,7 @@ describe('Basic inputs of Radio Button Group', () => {
 
   it('should pass correct size values to the Fieldset', () => {
     fudisInputSizeArray.forEach((size) => {
-      component.size = size;
+      fixture.componentRef.setInput('size', size);
       fixture.detectChanges();
 
       expect(fieldsetElement.classList).toContain(`fudis-input-size__${size}`);
@@ -135,7 +135,7 @@ describe('Basic inputs of Radio Button Group', () => {
   });
 
   it('should pass correct id', () => {
-    component.id = 'my-custom-radio-button-group';
+    fixture.componentRef.setInput('id', 'my-custom-radio-button-group');
     fixture.detectChanges();
 
     expect(fieldsetElement.getAttribute('id')).toEqual('my-custom-radio-button-group');

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.ts
@@ -11,6 +11,7 @@ import {
   DOCUMENT,
   ChangeDetectionStrategy,
   signal,
+  WritableSignal,
   Signal,
 } from '@angular/core';
 import { FudisInputSize, FudisRadioButtonChangeEvent } from '../../../types/forms';
@@ -84,10 +85,10 @@ export class RadioButtonGroupComponent
   /**
    * Private signals for managing the state and selected value of the radio button group
    */
-  private _selectedValue = signal<string | boolean | object | null | unknown>(null);
-  private _touched = signal(false);
-  private _invalid = signal(false);
-  private _disabled = signal(false);
+  private _selectedValue: WritableSignal<string | boolean | object | null | unknown> = signal(null);
+  private _touched: WritableSignal<boolean> = signal(false);
+  private _invalid: WritableSignal<boolean> = signal(false);
+  private _disabled: WritableSignal<boolean> = signal(false);
 
   /**
    * Publicly exposed readonly signals for template binding and external use (in single radio

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.ts
@@ -113,7 +113,7 @@ export class RadioButtonGroupComponent
     if (changes.control?.currentValue !== changes.control?.previousValue) {
       this._syncControlState();
       this._subscription?.unsubscribe();
-      this._subscription = this.control.valueChanges
+      this._subscription = this.control.events
         .pipe(takeUntilDestroyed(this._destroyRef))
         .subscribe(() => {
           this._syncControlState();
@@ -161,20 +161,6 @@ export class RadioButtonGroupComponent
     this._touched.set(this.control.touched);
     this._invalid.set(this.control.invalid);
     this._disabled.set(this.control.disabled);
-  }
-
-  /**
-   * Blur can mark the control as touched without changing its value. Sync the local state after
-   * Angular Forms finishes blur handling.
-   */
-  public onRadioBlur(event: FocusEvent): void {
-    this.handleBlur.emit(event);
-
-    // Wait for the current call stack to finish, allowing Angular Forms to update the control's states before syncing.
-    queueMicrotask(() => {
-      this._syncControlState();
-      this._updateValueAndValidityTrigger.next();
-    });
   }
 
   public triggerEmit(id: string, label: string): void {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button-group.component.ts
@@ -9,6 +9,9 @@ import {
   ViewChild,
   AfterViewInit,
   DOCUMENT,
+  ChangeDetectionStrategy,
+  signal,
+  Signal,
 } from '@angular/core';
 import { FudisInputSize, FudisRadioButtonChangeEvent } from '../../../types/forms';
 import { FudisValidatorUtilities } from '../../../utilities/form/validator-utilities';
@@ -18,7 +21,6 @@ import { FudisComponentChanges } from '../../../types/miscellaneous';
 import { ControlComponentBaseDirective } from '../../../directives/form/control-component-base/control-component-base.directive';
 import { FudisFocusService } from '../../../services/focus/focus.service';
 import { Subscription } from 'rxjs';
-
 import { GuidanceComponent } from '../guidance/guidance.component';
 import { FieldSetComponent } from '../fieldset/fieldset.component';
 import { FieldsetContentDirective } from '../fieldset/fieldset-content.directive';
@@ -41,6 +43,7 @@ import { AsyncPipe } from '@angular/common';
 @Component({
   selector: 'fudis-radio-button-group',
   templateUrl: './radio-button-group.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FieldSetComponent, FieldsetContentDirective, GuidanceComponent, AsyncPipe],
 })
 export class RadioButtonGroupComponent
@@ -78,20 +81,44 @@ export class RadioButtonGroupComponent
    */
   private _subscription: Subscription;
 
+  /**
+   * Private signals for managing the state and selected value of the radio button group
+   */
+  private _selectedValue = signal<string | boolean | object | null | unknown>(null);
+  private _touched = signal(false);
+  private _invalid = signal(false);
+  private _disabled = signal(false);
+
+  /**
+   * Publicly exposed readonly signals for template binding and external use (in single radio
+   * button). Not meant to be set from outside the component, but reflect the current state of the
+   * form control and selected value.
+   */
+  public readonly selectedValue: Signal<string | boolean | object | null | unknown> =
+    this._selectedValue.asReadonly();
+  public readonly touchedState: Signal<boolean> = this._touched.asReadonly();
+  public readonly invalidState: Signal<boolean> = this._invalid.asReadonly();
+  public readonly disabledState: Signal<boolean> = this._disabled.asReadonly();
+
   ngOnInit() {
     this._setParentComponentId('radio-button-group');
     this._updateValueAndValidityTrigger.next();
   }
 
   /**
-   * Add value and validity check when control value changes
+   * Sync local signals with FormControl states and add value and validity check when control value
+   * changes.
    */
   ngOnChanges(changes: FudisComponentChanges<RadioButtonGroupComponent>): void {
     if (changes.control?.currentValue !== changes.control?.previousValue) {
+      this._syncControlState();
       this._subscription?.unsubscribe();
       this._subscription = this.control.valueChanges
         .pipe(takeUntilDestroyed(this._destroyRef))
-        .subscribe(() => this._updateValueAndValidityTrigger.next());
+        .subscribe(() => {
+          this._syncControlState();
+          this._updateValueAndValidityTrigger.next();
+        });
     }
   }
 
@@ -124,12 +151,38 @@ export class RadioButtonGroupComponent
     return radio;
   }
 
+  /**
+   * Copy FormControl states into local signals
+   */
+  private _syncControlState(): void {
+    if (!this.control) return;
+
+    this._selectedValue.set(this.control.value);
+    this._touched.set(this.control.touched);
+    this._invalid.set(this.control.invalid);
+    this._disabled.set(this.control.disabled);
+  }
+
+  /**
+   * Blur can mark the control as touched without changing its value. Sync the local state after
+   * Angular Forms finishes blur handling.
+   */
+  public onRadioBlur(event: FocusEvent): void {
+    this.handleBlur.emit(event);
+
+    // Wait for the current call stack to finish, allowing Angular Forms to update the control's states before syncing.
+    queueMicrotask(() => {
+      this._syncControlState();
+      this._updateValueAndValidityTrigger.next();
+    });
+  }
+
   public triggerEmit(id: string, label: string): void {
     const data: FudisRadioButtonChangeEvent = {
       option: {
         id: id,
         label: label,
-        value: this.control?.value,
+        value: this._selectedValue(),
       },
       control: this.control,
     };

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button/radio-button.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button/radio-button.component.html
@@ -20,7 +20,7 @@
       [attr.aria-invalid]="(_parentGroup.touchedState() && _parentGroup.invalidState()) || null"
       (focus)="_parentGroup.onFocus($event)"
       (keyup)="_parentGroup.handleKeyUp.emit($event)"
-      (blur)="_parentGroup.onRadioBlur($event)"
+      (blur)="_parentGroup.handleBlur.emit($event)"
       (change)="_onChange()"
     />
     <div class="fudis-radio-button__content">

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button/radio-button.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button/radio-button.component.html
@@ -8,19 +8,19 @@
       type="radio"
       class="fudis-radio-button__input"
       [class.fudis-radio-button__input--disabled]="
-        _parentGroup.control.disabled || _parentGroup.disabled || null
+        _parentGroup.disabledState() || _parentGroup.disabled || null
       "
       [id]="_id"
       [formControl]="_parentGroup.control"
       [value]="value"
       [name]="_parentGroup.id"
       [attr.name]="_parentGroup.id"
-      [attr.tabindex]="_parentGroup.control.disabled || _parentGroup.disabled ? -1 : null"
-      [attr.aria-disabled]="_parentGroup.control.disabled || _parentGroup.disabled || null"
-      [attr.aria-invalid]="(_parentGroup.control.touched && _parentGroup.control.invalid) || null"
+      [attr.tabindex]="_parentGroup.disabledState() || _parentGroup.disabled ? -1 : null"
+      [attr.aria-disabled]="_parentGroup.disabledState() || _parentGroup.disabled || null"
+      [attr.aria-invalid]="(_parentGroup.touchedState() && _parentGroup.invalidState()) || null"
       (focus)="_parentGroup.onFocus($event)"
       (keyup)="_parentGroup.handleKeyUp.emit($event)"
-      (blur)="_parentGroup.handleBlur.emit($event)"
+      (blur)="_parentGroup.onRadioBlur($event)"
       (change)="_onChange()"
     />
     <div class="fudis-radio-button__content">
@@ -28,13 +28,13 @@
         <div
           class="fudis-radio-button__content__control"
           [class.fudis-radio-button__content__control--invalid]="
-            _parentGroup.control.touched && _parentGroup.control.invalid
+            _parentGroup.touchedState() && _parentGroup.invalidState()
           "
           [class.fudis-radio-button__content__control--disabled]="
-            _parentGroup.control.disabled || _parentGroup.disabled
+            _parentGroup.disabledState() || _parentGroup.disabled
           "
         >
-          @if (_parentGroup.control.value === value) {
+          @if (_parentGroup.selectedValue() === value) {
             <span class="fudis-radio-button__content__control__indicator"></span>
           }
         </div>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button/radio-button.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/radio-button-group/radio-button/radio-button.component.ts
@@ -6,8 +6,8 @@ import {
   ViewEncapsulation,
   OnInit,
   Host,
+  ChangeDetectionStrategy,
 } from '@angular/core';
-
 import { FudisIdService } from '../../../../services/id/id.service';
 import { FudisRadioButtonChangeEvent, FudisRadioButtonOption } from '../../../../types/forms';
 import { RadioButtonGroupComponent } from '../radio-button-group.component';
@@ -20,6 +20,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
   selector: 'fudis-radio-button',
   templateUrl: './radio-button.component.html',
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormsModule, ReactiveFormsModule],
 })
 export class RadioButtonComponent implements OnInit {
@@ -55,7 +56,7 @@ export class RadioButtonComponent implements OnInit {
     const optionToEmit: FudisRadioButtonOption<object> = {
       id: this._id,
       label: this.label,
-      value: this._parentGroup?.control.value,
+      value: this._parentGroup?.selectedValue(),
     };
 
     /**


### PR DESCRIPTION
https://funidata.atlassian.net/browse/DS-383

Converting RadioButton and RadioButtonGroup components to OnPush
- Created and populated private signals with current FormControl states and value
- Created and exposed public readonly signals for the use of child RadioButton
- Changed `control.valueChanges` to `control.events`
  - https://angular.dev/guide/forms/reactive-forms#unified-control-state-change-events
  - From Angular's `index.d.ts` JSdoc about `events` Observable: 
    -  _A multicasting observable that emits an event every time the state of the control changes. It emits for value, status, pristine or touched changes._
  
### Developer's checklist
- [ ] I wrote necessary unit tests
- [ ] I updated Storybook stories and documentation to reflect the latest changes
- [ ] I included visual regression tests for new UI design
- [ ] I tested my implementation with different browsers
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
- [ ] Together with the reviewer I can confirm that the implementation supports the following screenreader and browser combinations (NVDA + Firefox, VoiceOver + Chrome)