### PR TITLE
[Documentation]: fix grammar

### DIFF
--- a/ngx-fudis/projects/documentation/development/HowToContribute.mdx
+++ b/ngx-fudis/projects/documentation/development/HowToContribute.mdx
@@ -9,7 +9,7 @@ Fudis Design System is open for new development contributions in - and outside o
 
 ## Before contributing
 
-**All Fudis Design System proposals must be generic and they must solve commonly repeated challenges across learning services.** If the proposal is considered as project spesific, it will be discarded.
+**All Fudis Design System proposals must be generic and they must solve commonly repeated challenges across learning services.** If the proposal is considered as project specific, it will be discarded.
 Therefore, it's important to define the scope of your proposal — whether it's an improvement to an existing component or a completely new feature. The best way to get started is by becoming familiar with the existing Fudis component library.
 In addition to new feature proposals, contributions may include bug fixes or just documentation update requests. Do not hesitate to contact Fudis team in advance for help and guidance.
 

--- a/ngx-fudis/projects/documentation/development/dsPractises/ComponentChecklist.mdx
+++ b/ngx-fudis/projects/documentation/development/dsPractises/ComponentChecklist.mdx
@@ -19,7 +19,7 @@ import * as VersionSelectorStories from "../../../ngx-fudis/src/storybook-docs/v
 
   **Import** each component in their own `.stories.ts` file.
 
-  If component has ngMaterial or Angular dependencies, check that those are imported in `ngx-fudis.module.ts`. If Story has Story spesific imports or declarations, then include them in `moduleMetadata`.
+  If component has ngMaterial or Angular dependencies, check that those are imported in `ngx-fudis.module.ts`. If Story has Story specific imports or declarations, then include them in `moduleMetadata`.
 
 ```
 export default {
@@ -27,7 +27,7 @@ export default {
 	component: InsertNameHereComponent,
 	decorators: [
 		moduleMetadata({
-			declarations: [StorySpesificComponent],
+			declarations: [StorySpecificComponent],
 			imports: ["dependency-1", "dependency-2"],
 		}),
 	],
@@ -56,7 +56,7 @@ Check [Naming Conventions](/docs/documentation-development-ds-practises-naming-c
 - Component variants such as primary, secondary etc. should be documented. These variants should be accessed and controllable through Storybook Controls.
 - If needed, create own story for clearly "other/different version" of the component, e.g. Button vs. Button with Icon
 - Component all variants, can be documented as story by using Storybook template prop.
-  > _Note! This prevents component control through Controls. Template prop should be used mainly for a story spesific .mdx documentation files._
+  > _Note! This prevents component control through Controls. Template prop should be used mainly for a story specific .mdx documentation files._
 - Component has ArgTypes.
 - Component has its @Inputs and @Outputs listed with description and accepted values.
 - Components with event handlers have working actions.

--- a/ngx-fudis/projects/documentation/development/dsPractises/CreatingAComponent.mdx
+++ b/ngx-fudis/projects/documentation/development/dsPractises/CreatingAComponent.mdx
@@ -16,7 +16,7 @@ ng generate --project=ngx-fudis component components/new-component-name
 
 ```
 
-Or to a spesific directory:
+Or to a specific directory:
 
 ```
 ng generate --project=ngx-fudis component components/form/new-form-component

--- a/ngx-fudis/projects/documentation/development/dsPractises/ProjectStructure.mdx
+++ b/ngx-fudis/projects/documentation/development/dsPractises/ProjectStructure.mdx
@@ -25,7 +25,7 @@ Static asset files, like fonts, SVG icons and similar are located here.
 
 ### Components
 
-The molecules of Fudis, the components. Each component folder should contain files related to that spesific component, such as Storybook stories, documentation and unit tests.
+The molecules of Fudis, the components. Each component folder should contain files related to that specific component, such as Storybook stories, documentation and unit tests.
 
 ### Directives
 
@@ -39,7 +39,7 @@ Folder containing all services that Fudis components need. These include e.g. al
 
 Some of Fudis components use components from Angular Material. Theme folder contains theme definitions, which aim to preset default Angular Material theme as near to Fudis as possible.
 
-If you are using ngMaterial component and the default theme doesn't apply colors as you want, proceed with caution if you consider to customise the default theme. Consider instead, if creating a component spesific theme would fix your issue.
+If you are using ngMaterial component and the default theme doesn't apply colors as you want, proceed with caution if you consider to customise the default theme. Consider instead, if creating a component specific theme would fix your issue.
 
 ### Types
 

--- a/ngx-fudis/projects/documentation/development/dsPractises/WaysOfWorking.mdx
+++ b/ngx-fudis/projects/documentation/development/dsPractises/WaysOfWorking.mdx
@@ -37,7 +37,7 @@ Quite many of the formatting errors can be automatically fixed on save if you ha
 
 - Avoid using style override with `!important`
 
-- Occasionally it is unconvenient to follow the rules of Stylelint. E. g. if you need to do CSS sibling selection, but SCSS syntax with Stylelint thinks you are not following the good practises. In these occasions it is acceptable to add an ignore rule for that line of styling.
+- Occasionally it is inconvenient to follow the rules of Stylelint. E. g. if you need to do CSS sibling selection, but SCSS syntax with Stylelint thinks you are not following the good practises. In these occasions it is acceptable to add an ignore rule for that line of styling.
 
 ### Using Foundation Tokens and Mixins in Component's SCSS-file
 
@@ -61,7 +61,7 @@ To use foundations in component's scss file, import Core with SCSS's `@use` feat
 
 Under `theme` folder resides `fudis-theme.scss` and `palette.scss` files which include main style configurations for Fudis components using Angular Material as their base.
 
-If needed, you can create additional themes for the component and include that theme for a spesific component. E. g. `@include mat.datepicker-theme($fudis-datepicker-theme);` adds a spesific Datepicker theme just for the spesific datepicker component.
+If needed, you can create additional themes for the component and include that theme for a specific component. E. g. `@include mat.datepicker-theme($fudis-datepicker-theme);` adds a specific Datepicker theme just for the specific datepicker component.
 
 #### Custom styling outside ngMaterial theming API
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid-item/grid-item.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid-item/grid-item.mdx
@@ -38,7 +38,7 @@ Grid Item has properties of `alignSelfX` for horizontal and `alignSelfY` for ver
 
 ## Defining Columns Expansion and Position
 
-When defining the parent Grid Component's `columns` property, by default all Grid Items follow that spesified rule. The same `columns` property is available to a single Grid Item, which will override parent's rules. The given value is converted or used as it is to a native CSS Grid `grid-columns` attribute.
+When defining the parent Grid Component's `columns` property, by default all Grid Items follow that specified rule. The same `columns` property is available to a single Grid Item, which will override parent's rules. The given value is converted or used as it is to a native CSS Grid `grid-columns` attribute.
 
 - [Setting Grid Item To Stretch Whole Width](#setting-grid-item-to-stretch-whole-width)
 - [Using A Number Value For Columns](#using-a-number-value-for-columns)

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid/grid.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/grid/grid/grid.mdx
@@ -7,7 +7,7 @@ import * as VersionSelectorStories from "../../../../storybook-docs/version-sele
 
 # Grid Component
 
-Grid Component is a wrapper element, which implements all the features spesified in [Grid Directive](/docs/directives-grid-grid--documentation).
+Grid Component is a wrapper element, which implements all the features specified in [Grid Directive](/docs/directives-grid-grid--documentation).
 
 Essentially it is an HTML element which has CSS property `display` set to `grid`.
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/form-actions/form-actions.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/directives/form/form-actions/form-actions.mdx
@@ -9,7 +9,7 @@ import * as VersionSelectorStories from "../../../../storybook-docs/version-sele
 
 When using Form component, it should always have a Button which submits the form. For proper accessibility, the submit Button **must be** a child component of Form component.
 
-When you want to bind a spesific Button to be Form's submit button, you can use `fudisFormSubmit` directive to it.
+When you want to bind a specific Button to be Form's submit button, you can use `fudisFormSubmit` directive to it.
 
 You should also bind boolean property `formValid` to the Button.
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/error-summary-service.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/error-summary-service.mdx
@@ -47,7 +47,7 @@ protected _submitButtonClick():void {
 	if(this.form.invalid){
 		// @Input property of Form
 		this._errorSummaryVisible = true;
-		// Reload errors of the spesific Form
+		// Reload errors of the specific Form
 		this._service.reloadFormErrors("id-of-my-form");
 	} else {
 		this._errorSummaryVisible = false;
@@ -78,7 +78,7 @@ _Note!_ Adding errors manually does not affect any FormControl's validity. It is
 
 ### Remove Error
 
-To remove previously added error, three parameters described above, need to be spesified: `id`, `formId` and `focusId`
+To remove previously added error, three parameters described above, need to be specified: `id`, `formId` and `focusId`
 
 ```
 this._service.removeError('app-custom-error-abc123', 'app-create-user-form', 'app-username-input')

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/error-summary.service.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/error-summary.service.ts
@@ -57,7 +57,7 @@ export class FudisErrorSummaryService {
   }
 
   /**
-   * Reload a spesific Form Id
+   * Reload a specific Form Id
    *
    * @param id Form Id
    * @param focus Focus to Error Summary
@@ -76,7 +76,7 @@ export class FudisErrorSummaryService {
   }
 
   /**
-   * To add message to spesific Form's Error Summary.
+   * To add message to specific Form's Error Summary.
    *
    * @param id Identifier of the message, eg. 'app-custom-error-abc123'
    * @param formId Id of Form component

--- a/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/internal-error-summary.service.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/services/form/error-summary/internal-error-summary.service.ts
@@ -152,7 +152,7 @@ export class FudisInternalErrorSummaryService implements OnDestroy {
   }
 
   /**
-   * Hide or show Error Summary of spesific Form Component
+   * Hide or show Error Summary of specific Form Component
    *
    * @param formId Form to target
    * @param visible Hide or show Error Summary

--- a/ngx-fudis/projects/ngx-fudis/src/lib/utilities/form/validators.mdx
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/utilities/form/validators.mdx
@@ -6,7 +6,7 @@ import * as VersionSelectorStories from "../../../storybook-docs/version-selecto
 # Validators & Validator Utilities
 
 Fudis Form components use two set of validators; **FudisValidators** and **FudisGroupValidators**.
-For custom application spesific validator, please check [Custom Validators and Error Messages](#custom-validators-and-error-messages) section on this page.
+For custom application specific validator, please check [Custom Validators and Error Messages](#custom-validators-and-error-messages) section on this page.
 
 Basic validators (FudisValidators) have the following types: `required`, `email`, `minLength`, `maxLength`,`min`, `max`, `pattern`, `datepickerMin` and `datepickerMax`.
 


### PR DESCRIPTION
DS-659

Fixed two grammar mistakes used in the docs:
- "spesific" --> "specific"
- "unconvenient" --> "inconvenient"

### Developer's checklist
- [ ] I wrote necessary unit tests
- [ ] I updated Storybook stories and documentation to reflect the latest changes
- [ ] I included visual regression tests for new UI design
- [ ] I tested my implementation with different browsers
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
- [ ] Together with the reviewer I can confirm that the implementation supports the following screenreader and browser combinations (NVDA + Firefox, VoiceOver + Chrome)
