### PR TITLE
[Datepicker, DateRange]: Convert to OnPush

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/date-range/date-range.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/date-range/date-range.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
 import { FudisIdService } from '../../../../services/id/id.service';
 import { BehaviorSubject } from 'rxjs';
 import { FudisComponentChanges } from '../../../../types/miscellaneous';
@@ -21,6 +21,7 @@ import { FudisComponentChanges } from '../../../../types/miscellaneous';
   selector: 'fudis-date-range',
   templateUrl: './date-range.component.html',
   styleUrls: ['./date-range.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DateRangeComponent implements OnChanges {
   constructor(private _idService: FudisIdService) {}

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.html
@@ -23,8 +23,8 @@
       [max]="_maxDate"
       [placeholder]="_placeholderString | async"
       [attr.tabindex]="disabled ? -1 : null"
-      [attr.aria-disabled]="control.disabled || disabled || null"
-      [attr.aria-invalid]="(control.invalid && control.touched) || null"
+      [attr.aria-disabled]="_disabled() || disabled || null"
+      [attr.aria-invalid]="(_invalid() && _touched()) || null"
       [attr.required]="(_required | async) || null"
       [attr.aria-describedby]="id + '_guidance'"
     />
@@ -33,13 +33,13 @@
       class="fudis-datepicker__toggle"
       [id]="id + '-calendar-icon-toggle'"
       [for]="picker"
-      [disabled]="control.disabled || disabled"
+      [disabled]="_disabled() || disabled"
       [disableRipple]="true"
     >
       <mat-icon matDatepickerToggleIcon>
         <fudis-icon
           [icon]="'calendar'"
-          [color]="control.disabled || disabled ? 'gray-dark' : 'primary'"
+          [color]="_disabled() || disabled ? 'gray-dark' : 'primary'"
         ></fudis-icon>
       </mat-icon>
     </mat-datepicker-toggle>

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.spec.ts
@@ -139,11 +139,16 @@ describe('DatepickerComponent', () => {
     });
 
     it('should update control validity and visible input value according to given min validator and value', () => {
-      
-      fixture.componentRef.setInput('control', new FormControl(null, FudisValidators.datepickerMin({
-          value: new Date('2024-01-12'),
-          message: 'Date is not inside allowed range',
-        })));
+      fixture.componentRef.setInput(
+        'control',
+        new FormControl(
+          null,
+          FudisValidators.datepickerMin({
+            value: new Date('2024-01-12'),
+            message: 'Date is not inside allowed range',
+          }),
+        ),
+      );
       component.control.markAsTouched();
       fixture.detectChanges();
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.spec.ts
@@ -172,12 +172,17 @@ describe('DatepickerComponent', () => {
     });
 
     it('should update control validity according to given max validator and value', () => {
-      
-      fixture.componentRef.setInput('control', new FormControl(null, FudisValidators.datepickerMax({
-          value: new Date('2025-01-01'),
-          message: 'Date is not inside allowed range',
-        })));
-      
+      fixture.componentRef.setInput(
+        'control',
+        new FormControl(
+          null,
+          FudisValidators.datepickerMax({
+            value: new Date('2025-01-01'),
+            message: 'Date is not inside allowed range',
+          }),
+        ),
+      );
+
       fixture.detectChanges();
 
       component.control.patchValue(new Date('2025-01-10'));

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.spec.ts
@@ -25,8 +25,8 @@ describe('DatepickerComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(DatepickerComponent);
     component = fixture.componentInstance;
-    component.control = new FormControl(null);
-    component.label = 'Select a date';
+    fixture.componentRef.setInput('control', new FormControl(null));
+    fixture.componentRef.setInput('label', 'Select a date');
     fixture.detectChanges();
   });
 
@@ -43,7 +43,7 @@ describe('DatepickerComponent', () => {
 
     it('should change CSS classes according to the given datepicker input size', () => {
       fudisInputSizeArray.forEach((size) => {
-        component.size = size;
+        fixture.componentRef.setInput('size', size);
         fixture.detectChanges();
 
         expect(sortClasses(wrapperElement.className)).toEqual(
@@ -67,7 +67,7 @@ describe('DatepickerComponent', () => {
 
       expect(childGuidanceElement).toBeTruthy();
 
-      component.helpText = 'Select your favourite date';
+      fixture.componentRef.setInput('helpText', 'Select your favourite date');
       fixture.detectChanges();
 
       const guidanceHelpText = fixture.debugElement.nativeElement.querySelector(
@@ -88,7 +88,7 @@ describe('DatepickerComponent', () => {
 
     it('should have invalid attribute if datepicker is required, input is touched and no date has been chosen', () => {
       const requiredControl = new FormControl(null, FudisValidators.required('Date is required'));
-      component.control = requiredControl;
+      fixture.componentRef.setInput('control', requiredControl);
       fixture.detectChanges();
 
       datepickerInput.dispatchEvent(new Event('focus'));
@@ -129,7 +129,7 @@ describe('DatepickerComponent', () => {
 
   describe('Control updates', () => {
     it('should have no value selected', () => {
-      component.control = new FormControl(null);
+      fixture.componentRef.setInput('control', new FormControl(null));
       fixture.detectChanges();
 
       const inputEl = getElement(fixture, 'input') as HTMLInputElement;
@@ -139,13 +139,11 @@ describe('DatepickerComponent', () => {
     });
 
     it('should update control validity and visible input value according to given min validator and value', () => {
-      component.control = new FormControl(
-        null,
-        FudisValidators.datepickerMin({
+      
+      fixture.componentRef.setInput('control', new FormControl(null, FudisValidators.datepickerMin({
           value: new Date('2024-01-12'),
           message: 'Date is not inside allowed range',
-        }),
-      );
+        })));
       component.control.markAsTouched();
       fixture.detectChanges();
 
@@ -174,13 +172,12 @@ describe('DatepickerComponent', () => {
     });
 
     it('should update control validity according to given max validator and value', () => {
-      component.control = new FormControl(
-        null,
-        FudisValidators.datepickerMax({
+      
+      fixture.componentRef.setInput('control', new FormControl(null, FudisValidators.datepickerMax({
           value: new Date('2025-01-01'),
           message: 'Date is not inside allowed range',
-        }),
-      );
+        })));
+      
       fixture.detectChanges();
 
       component.control.patchValue(new Date('2025-01-10'));

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.ts
@@ -1,5 +1,6 @@
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   Component,
   Host,
   HostListener,
@@ -11,6 +12,7 @@ import {
   ViewChild,
   ViewEncapsulation,
   effect,
+  signal,
 } from '@angular/core';
 import { FormControl, AbstractControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';
@@ -50,6 +52,7 @@ import { AsyncPipe } from '@angular/common';
   selector: 'fudis-datepicker',
   templateUrl: './datepicker.component.html',
   styleUrls: ['./datepicker.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   providers: [
     {
@@ -210,6 +213,19 @@ export class DatepickerComponent
   protected _placeholderString = new BehaviorSubject<string>('');
 
   /**
+   * Signals reflecting the current state of the form control, updated on every control event.
+   */
+  protected _touched = signal(false);
+  protected _invalid = signal(false);
+  protected _disabled = signal(false);
+
+  private _syncControlState(): void {
+    this._touched.set(this.control.touched);
+    this._invalid.set(this.control.invalid);
+    this._disabled.set(this.control.disabled);
+  }
+
+  /**
    * Instance of Datepicker Parse validator
    */
   private _parseValidatorInstance: FudisValidatorFn | null;
@@ -218,6 +234,7 @@ export class DatepickerComponent
    * Subscription for handling the valueChanges observable
    */
   private _subscription: Subscription;
+  private _dateCrossingSubscription: Subscription;
 
   /**
    * Validator reads HTML input field and checks if it can be converted to valid Date object
@@ -293,19 +310,23 @@ export class DatepickerComponent
     // Do checks for the control to define attributes used in e.g. HTML
     if (changes.control?.currentValue !== changes.control?.previousValue) {
       this._subscription?.unsubscribe();
+      this._syncControlState();
       this._updateValueAndValidityTrigger.next();
-      // Subscribe to control value changes and call parent's date crossing check with current value and Date Range input type
+
+      this._subscription = this.control.events
+        .pipe(takeUntilDestroyed(this._destroyRef))
+        .subscribe(() => {
+          this._syncControlState();
+          this._updateValueAndValidityTrigger.next();
+        });
+
       if (this._parentDateRange && this.dateRangeType) {
-        this._subscription = this.control.valueChanges
+        this._dateCrossingSubscription?.unsubscribe();
+        this._dateCrossingSubscription = this.control.valueChanges
           .pipe(takeUntilDestroyed(this._destroyRef))
           .subscribe((value) => {
-            this._updateValueAndValidityTrigger.next();
             this._parentDateRange?.checkDateCrossings(value, this.dateRangeType!);
           });
-      } else {
-        this._subscription = this.control.valueChanges
-          .pipe(takeUntilDestroyed(this._destroyRef))
-          .subscribe(() => this._updateValueAndValidityTrigger.next());
       }
 
       // If control changes and these checks are on, add parseValidator

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.ts
@@ -13,6 +13,7 @@ import {
   ViewEncapsulation,
   effect,
   signal,
+  WritableSignal
 } from '@angular/core';
 import { FormControl, AbstractControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';
@@ -215,9 +216,9 @@ export class DatepickerComponent
   /**
    * Signals reflecting the current state of the form control, updated on every control event.
    */
-  protected _touched = signal(false);
-  protected _invalid = signal(false);
-  protected _disabled = signal(false);
+  protected _touched: WritableSignal<boolean> = signal(false);
+  protected _invalid: WritableSignal<boolean> = signal(false);
+  protected _disabled: WritableSignal<boolean> = signal(false);
 
   private _syncControlState(): void {
     this._touched.set(this.control.touched);

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.ts
@@ -13,7 +13,7 @@ import {
   ViewEncapsulation,
   effect,
   signal,
-  WritableSignal
+  WritableSignal,
 } from '@angular/core';
 import { FormControl, AbstractControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/date/datepicker/datepicker.component.ts
@@ -313,6 +313,7 @@ export class DatepickerComponent
       this._syncControlState();
       this._updateValueAndValidityTrigger.next();
 
+      // Subscribe to control events to update the state signals and trigger value and validity updates
       this._subscription = this.control.events
         .pipe(takeUntilDestroyed(this._destroyRef))
         .subscribe(() => {
@@ -320,6 +321,7 @@ export class DatepickerComponent
           this._updateValueAndValidityTrigger.next();
         });
 
+      // Subscribe to control value changes and call parent's date crossing check with current value and Date Range input type
       if (this._parentDateRange && this.dateRangeType) {
         this._dateCrossingSubscription?.unsubscribe();
         this._dateCrossingSubscription = this.control.valueChanges


### PR DESCRIPTION
DS-382

- Changed DatepickerComponent and DateRangeComponent to use OnPush
- Added _touched, _invalid, and _disabled signals to DatepickerComponent with a _syncControlState() method to keep them in sync
- Replaced control.valueChanges subscription with control.events for state syncing
- Kept a separate control.valueChanges subscription for date range crossing checks (stored in its own _dateCrossingSubscription field so it can be properly unsubscribed when the control changes)
  
### Developer's checklist
- [ ] I wrote necessary unit tests
- [ ] I updated Storybook stories and documentation to reflect the latest changes
- [ ] I included visual regression tests for new UI design
- [ ] I tested my implementation with different browsers
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
- [ ] Together with the reviewer I can confirm that the implementation supports the following screenreader and browser combinations (NVDA + Firefox, VoiceOver + Chrome)
