### PR TITLE
[Form]: Convert to OnPush

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.html
@@ -66,7 +66,7 @@
 </form>
 
 <ng-template #errorSummary>
-  @if (_elementRef.nativeElement && _errorSummaryVisibleSignal()) {
+  @if (_elementRef.nativeElement && _errorSummaryVisible()) {
     <fudis-error-summary
       [formId]="id"
       (handleUpdatedErrorList)="handleUpdatedErrorList.emit($event)"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.html
@@ -66,7 +66,7 @@
 </form>
 
 <ng-template #errorSummary>
-  @if (_elementRef.nativeElement && (errorSummaryVisible || _errorSummaryVisibleSignal())) {
+  @if (_elementRef.nativeElement && _errorSummaryVisibleSignal()) {
     <fudis-error-summary
       [formId]="id"
       (handleUpdatedErrorList)="handleUpdatedErrorList.emit($event)"

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
@@ -123,7 +123,8 @@ export class FormComponent extends GridApiDirective implements OnInit, OnDestroy
   @Output() handleUpdatedErrorList = new EventEmitter<{ id: string; message: string }[] | null>();
 
   /**
-   * The _errorSummaryVisible signal tracks the current visibility of the error summary for template binding
+   * The _errorSummaryVisible signal tracks the current visibility of the error summary for template
+   * binding
    */
   protected _errorSummaryVisible: WritableSignal<boolean> = signal<boolean>(false);
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
@@ -14,6 +14,7 @@ import {
   EventEmitter,
   Output,
   ChangeDetectionStrategy,
+  WritableSignal,
 } from '@angular/core';
 import { FudisHeadingVariant, FudisHeadingLevel } from '../../../types/typography';
 import { FudisIdService } from '../../../services/id/id.service';
@@ -122,10 +123,9 @@ export class FormComponent extends GridApiDirective implements OnInit, OnDestroy
   @Output() handleUpdatedErrorList = new EventEmitter<{ id: string; message: string }[] | null>();
 
   /**
-   * Angular Change Detection did not trigger when we tried to update only our internal
-   * errorSummaryVisible input, hence we need this "helper signal"
+   * The _errorSummaryVisible signal tracks the current visibility of the error summary for template binding
    */
-  protected _errorSummaryVisibleSignal = signal<boolean>(false);
+  protected _errorSummaryVisible: WritableSignal<boolean> = signal<boolean>(false);
 
   private _injector = inject(Injector);
 
@@ -137,6 +137,7 @@ export class FormComponent extends GridApiDirective implements OnInit, OnDestroy
     }
 
     this._errorSummaryService.registerNewForm(this.id, this.errorSummaryVisible);
+    this._errorSummaryVisible.set(this.errorSummaryVisible);
 
     if (this._dialogParent) {
       this._dialogParent.closeButtonPositionAbsolute.set(true);
@@ -145,10 +146,7 @@ export class FormComponent extends GridApiDirective implements OnInit, OnDestroy
     toObservable(this._errorSummaryService.errorSummaryVisibilityStatus[this.id], {
       injector: this._injector,
     }).subscribe((value) => {
-      if (value !== this.errorSummaryVisible) {
-        this.errorSummaryVisible = !this.errorSummaryVisible;
-        this._errorSummaryVisibleSignal.set(this.errorSummaryVisible);
-      }
+      this._errorSummaryVisible.set(value);
     });
   }
 
@@ -162,7 +160,7 @@ export class FormComponent extends GridApiDirective implements OnInit, OnDestroy
       this.id
     ) {
       this._errorSummaryService.setErrorSummaryVisibility(this.id, this.errorSummaryVisible);
-      this._errorSummaryVisibleSignal.set(this.errorSummaryVisible);
+      this._errorSummaryVisible.set(this.errorSummaryVisible);
     }
   }
 

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/form/form.component.ts
@@ -13,6 +13,7 @@ import {
   signal,
   EventEmitter,
   Output,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import { FudisHeadingVariant, FudisHeadingLevel } from '../../../types/typography';
 import { FudisIdService } from '../../../services/id/id.service';
@@ -44,6 +45,7 @@ import { ErrorSummaryComponent } from '../error-summary/error-summary.component'
   templateUrl: './form.component.html',
   styleUrls: ['./form.component.scss'],
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     FormsModule,
     GridDirective,


### PR DESCRIPTION
DS-389

Converted the form component to use onpush. Small change done in the template, because after changing to onpush, the signal in the template was not read because of the ||-operator short-circuiting

### Developer's checklist
- [ ] I wrote necessary unit tests
- [ ] I updated Storybook stories and documentation to reflect the latest changes
- [ ] I included visual regression tests for new UI design
- [ ] I tested my implementation with different browsers
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
- [ ] Together with the reviewer I can confirm that the implementation supports the following screenreader and browser combinations (NVDA + Firefox, VoiceOver + Chrome)
