### PR TITLE
[Guidance]: Convert to OnPush

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.html
@@ -123,8 +123,7 @@
           class="fudis-guidance__character-limit-indicator__alert fudis-visually-hidden"
           role="alert"
         >
-          {{ singleControl.value.value?.length || 0 }}/{{ maxLength }}
-          {{ _maxLengthText() }}</p
+          {{ singleControl.value.value?.length || 0 }}/{{ maxLength }} {{ _maxLengthText() }}</p
         >
       }
     }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.html
@@ -6,12 +6,12 @@
       [id]="_id + '-errors'"
       [class.fudis-guidance__errors]="
         _afterViewInitDone() &&
-        ((control && control.touched) || (formGroup && formGroup.touched && groupBlurredOut))
+        ((control && _controlTouched()) || (formGroup && _formGroupTouched() && groupBlurredOut))
       "
     >
       @if (
-        (control?.invalid && control?.touched) ||
-        (formGroup?.invalid && formGroup?.touched && groupBlurredOut)
+        (_controlInvalid() && _controlTouched()) ||
+        (_formGroupInvalid() && _formGroupTouched() && groupBlurredOut)
       ) {
         <fudis-icon [icon]="'alert-fill'" />
       }
@@ -19,7 +19,7 @@
         <!--
         Check errors for each control FormGroup e. g. english, finnish, swedish
         -->
-        @if (formGroup?.controls && !control && !formGroup?.errors) {
+        @if (formGroup?.controls && !control && !_formGroupErrors()) {
           @for (singleControl of formGroup?.controls | keyvalue; track singleControl.key) {
             @if (singleControl.value.errors) {
               @for (error of singleControl.value.errors | keyvalue; track error.key) {
@@ -29,7 +29,7 @@
                     [formId]="parentFormId"
                     [focusId]="for"
                     [visible]="
-                      !!((singleControl.value.touched || formGroup.touched) && groupBlurredOut)
+                      !!((singleControl.value.touched || _formGroupTouched()) && groupBlurredOut)
                     "
                     [type]="error.key"
                     [controlName]="singleControl.key"
@@ -45,13 +45,13 @@
         <!--
         Check parent level errors of FormGroup e. g. oneRequired
         -->
-        @if (formGroup?.errors && formGroup?.invalid) {
-          @for (error of formGroup?.errors | keyvalue; track error.key) {
+        @if (_formGroupErrors() && _formGroupInvalid()) {
+          @for (error of _formGroupErrors()! | keyvalue; track error.key) {
             @if (error.value?.message) {
               <fudis-validator-error-message
                 (handleCreateError)="_reloadErrorSummaryOnLazyLoad($event)"
                 [formId]="parentFormId"
-                [visible]="!!(formGroup.touched && groupBlurredOut)"
+                [visible]="!!(_formGroupTouched() && groupBlurredOut)"
                 [focusId]="for"
                 [type]="error.key"
                 [label]="inputLabel"
@@ -64,13 +64,13 @@
         <!--
         Check errors for single FormControl e. g. single text-input with maxlength error
         -->
-        @if (control?.errors && !formGroup) {
-          @for (error of control.errors | keyvalue; track error.key) {
+        @if (_controlErrors() && !formGroup) {
+          @for (error of _controlErrors()! | keyvalue; track error.key) {
             @if (error.value?.message) {
               <fudis-validator-error-message
                 (handleCreateError)="_reloadErrorSummaryOnLazyLoad($event)"
                 [formId]="parentFormId"
-                [visible]="control.touched"
+                [visible]="_controlTouched()"
                 [focusId]="for"
                 [type]="error.key"
                 [label]="inputLabel"
@@ -98,7 +98,7 @@
       }}"
       [class.fudis-guidance__character-limit-indicator__float-right]="!helpText"
     >
-      {{ control.value?.length || 0 }}/{{ maxLength }}
+      {{ _controlValueLength() }}/{{ maxLength }}
       <span class="fudis-visually-hidden">{{ _maxLengthText() }}</span>
     </small>
   }
@@ -133,9 +133,9 @@
 @if (
   control &&
   maxLength &&
-  (control.value?.length === _maxLengthAlertThreshold || control.value?.length === maxLength)
+  (_controlValueLength() === _maxLengthAlertThreshold || _controlValueLength() === maxLength)
 ) {
   <p class="fudis-guidance__character-limit-indicator__alert fudis-visually-hidden" role="alert"
-    >{{ control.value?.length || 0 }}/{{ maxLength }} {{ _maxLengthText() }}</p
+    >{{ _controlValueLength() }}/{{ maxLength }} {{ _maxLengthText() }}</p
   >
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.html
@@ -6,12 +6,12 @@
       [id]="_id + '-errors'"
       [class.fudis-guidance__errors]="
         _afterViewInitDone() &&
-        ((control && _controlTouched()) || (formGroup && _formGroupTouched() && groupBlurredOut))
+        ((control && control.touched) || (formGroup && formGroup.touched && groupBlurredOut))
       "
     >
       @if (
-        (_controlInvalid() && _controlTouched()) ||
-        (_formGroupInvalid() && _formGroupTouched() && groupBlurredOut)
+        (control?.invalid && control?.touched) ||
+        (formGroup?.invalid && formGroup?.touched && groupBlurredOut)
       ) {
         <fudis-icon [icon]="'alert-fill'" />
       }
@@ -19,7 +19,7 @@
         <!--
         Check errors for each control FormGroup e. g. english, finnish, swedish
         -->
-        @if (formGroup?.controls && !control && !_formGroupErrors()) {
+        @if (formGroup?.controls && !control && !formGroup?.errors) {
           @for (singleControl of formGroup?.controls | keyvalue; track singleControl.key) {
             @if (singleControl.value.errors) {
               @for (error of singleControl.value.errors | keyvalue; track error.key) {
@@ -29,7 +29,7 @@
                     [formId]="parentFormId"
                     [focusId]="for"
                     [visible]="
-                      !!((singleControl.value.touched || _formGroupTouched()) && groupBlurredOut)
+                      !!((singleControl.value.touched || formGroup.touched) && groupBlurredOut)
                     "
                     [type]="error.key"
                     [controlName]="singleControl.key"
@@ -45,13 +45,13 @@
         <!--
         Check parent level errors of FormGroup e. g. oneRequired
         -->
-        @if (_formGroupErrors() && _formGroupInvalid()) {
-          @for (error of _formGroupErrors()! | keyvalue; track error.key) {
+        @if (formGroup?.errors && formGroup?.invalid) {
+          @for (error of formGroup?.errors | keyvalue; track error.key) {
             @if (error.value?.message) {
               <fudis-validator-error-message
                 (handleCreateError)="_reloadErrorSummaryOnLazyLoad($event)"
                 [formId]="parentFormId"
-                [visible]="!!(_formGroupTouched() && groupBlurredOut)"
+                [visible]="!!(formGroup.touched && groupBlurredOut)"
                 [focusId]="for"
                 [type]="error.key"
                 [label]="inputLabel"
@@ -64,13 +64,13 @@
         <!--
         Check errors for single FormControl e. g. single text-input with maxlength error
         -->
-        @if (_controlErrors() && !formGroup) {
-          @for (error of _controlErrors()! | keyvalue; track error.key) {
+        @if (control?.errors && !formGroup) {
+          @for (error of control.errors | keyvalue; track error.key) {
             @if (error.value?.message) {
               <fudis-validator-error-message
                 (handleCreateError)="_reloadErrorSummaryOnLazyLoad($event)"
                 [formId]="parentFormId"
-                [visible]="_controlTouched()"
+                [visible]="control.touched"
                 [focusId]="for"
                 [type]="error.key"
                 [label]="inputLabel"
@@ -98,7 +98,7 @@
       }}"
       [class.fudis-guidance__character-limit-indicator__float-right]="!helpText"
     >
-      {{ _controlValueLength() }}/{{ maxLength }}
+      {{ control.value?.length || 0 }}/{{ maxLength }}
       <span class="fudis-visually-hidden">{{ _maxLengthText() }}</span>
     </small>
   }
@@ -133,9 +133,9 @@
 @if (
   control &&
   maxLength &&
-  (_controlValueLength() === _maxLengthAlertThreshold || _controlValueLength() === maxLength)
+  (control.value?.length === _maxLengthAlertThreshold || control.value?.length === maxLength)
 ) {
   <p class="fudis-guidance__character-limit-indicator__alert fudis-visually-hidden" role="alert"
-    >{{ _controlValueLength() }}/{{ maxLength }} {{ _maxLengthText() }}</p
+    >{{ control.value?.length || 0 }}/{{ maxLength }} {{ _maxLengthText() }}</p
   >
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.html
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.html
@@ -99,7 +99,7 @@
       [class.fudis-guidance__character-limit-indicator__float-right]="!helpText"
     >
       {{ control.value?.length || 0 }}/{{ maxLength }}
-      <span class="fudis-visually-hidden">{{ _maxLengthText | async }}</span>
+      <span class="fudis-visually-hidden">{{ _maxLengthText() }}</span>
     </small>
   }
   @if (formGroup?.controls && !control && maxLength) {
@@ -112,7 +112,7 @@
           [class.fudis-guidance__character-limit-indicator__float-right]="!helpText"
         >
           {{ singleControl.value.value?.length || 0 }}/{{ maxLength }}
-          <span class="fudis-visually-hidden">{{ _maxLengthText | async }}</span>
+          <span class="fudis-visually-hidden">{{ _maxLengthText() }}</span>
         </small>
       }
       @if (
@@ -124,7 +124,7 @@
           role="alert"
         >
           {{ singleControl.value.value?.length || 0 }}/{{ maxLength }}
-          {{ _maxLengthText | async }}</p
+          {{ _maxLengthText() }}</p
         >
       }
     }
@@ -136,6 +136,6 @@
   (control.value?.length === _maxLengthAlertThreshold || control.value?.length === maxLength)
 ) {
   <p class="fudis-guidance__character-limit-indicator__alert fudis-visually-hidden" role="alert"
-    >{{ control.value?.length || 0 }}/{{ maxLength }} {{ _maxLengthText | async }}</p
+    >{{ control.value?.length || 0 }}/{{ maxLength }} {{ _maxLengthText() }}</p
   >
 }

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.spec.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.spec.ts
@@ -50,10 +50,10 @@ describe('GuidanceComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(GuidanceComponent);
     component = fixture.componentInstance;
-    component.inputLabel = 'Test Label';
-    component.for = 'related-input-id';
-    component.helpText = 'This is describing guidance text';
-    component.maxLength = testMaxLength;
+    fixture.componentRef.setInput('inputLabel', 'Test Label');
+    fixture.componentRef.setInput('for', 'related-input-id');
+    fixture.componentRef.setInput('helpText', 'This is describing guidance text');
+    fixture.componentRef.setInput('maxLength', testMaxLength);
     fixture.detectChanges();
   });
 
@@ -80,7 +80,7 @@ describe('GuidanceComponent', () => {
 
   describe('with single Form Control', () => {
     beforeEach(() => {
-      component.control = testControl;
+      fixture.componentRef.setInput('control', testControl);
       component.control.markAsUntouched();
       fixture.detectChanges();
     });
@@ -151,8 +151,9 @@ describe('GuidanceComponent', () => {
 
   describe('with Form Group', () => {
     beforeEach(() => {
-      component.formGroup = testFormGroup;
-      component.groupBlurredOut = true;
+      fixture.componentRef.setInput('formGroup', testFormGroup);
+
+      fixture.componentRef.setInput('groupBlurredOut', true);
       component.formGroup.controls['finnish'].markAsUntouched();
       component.formGroup.controls['swedish'].markAsUntouched();
       component.formGroup.controls['english'].markAsUntouched();
@@ -167,7 +168,7 @@ describe('GuidanceComponent', () => {
       });
 
       it('should have correct number in max length indicator when selected option is set', () => {
-        component.selectedOption = 'swedish';
+        fixture.componentRef.setInput('selectedOption', 'swedish');
 
         fixture.detectChanges();
 
@@ -216,7 +217,7 @@ describe('GuidanceComponent', () => {
       });
 
       it('should not show errors when groupBlurred out is false', () => {
-        component.groupBlurredOut = false;
+        fixture.componentRef.setInput('groupBlurredOut', false);
         fixture.detectChanges();
 
         const errorList = getAllElements(fixture, 'fudis-validator-error-message p');
@@ -254,7 +255,7 @@ describe('GuidanceComponent', () => {
 
     describe('group errors', () => {
       beforeEach(() => {
-        component.formGroup = testFormGroupWithGroupValidator;
+        fixture.componentRef.setInput('formGroup', testFormGroupWithGroupValidator);
         fixture.detectChanges();
       });
       it('should display right amount of errors', () => {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.ts
@@ -1,5 +1,6 @@
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   DestroyRef,
   ElementRef,
@@ -14,7 +15,7 @@ import {
   Injector,
   WritableSignal,
 } from '@angular/core';
-import { FormControl, FormGroup, ValidationErrors } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 import { FudisTranslationService } from '../../../services/translation/translation.service';
 import { FudisIdService } from '../../../services/id/id.service';
 import { FudisInternalErrorSummaryService } from '../../../services/form/error-summary/internal-error-summary.service';
@@ -102,15 +103,6 @@ export class GuidanceComponent implements OnChanges, OnInit, AfterContentInit, A
    */
   protected _maxLengthText: WritableSignal<string> = signal<string>('');
 
-  protected _controlTouched: WritableSignal<boolean> = signal<boolean>(false);
-  protected _controlInvalid: WritableSignal<boolean> = signal<boolean>(false);
-  protected _controlErrors: WritableSignal<ValidationErrors | null> = signal<ValidationErrors | null>(null);
-  protected _controlValueLength: WritableSignal<number> = signal<number>(0);
-
-  protected _formGroupTouched: WritableSignal<boolean> = signal<boolean>(false);
-  protected _formGroupInvalid: WritableSignal<boolean> = signal<boolean>(false);
-  protected _formGroupErrors: WritableSignal<ValidationErrors | null> = signal<ValidationErrors | null>(null);
-
   /**
    * Number of characters left when screen reader is alerted about input max length
    */
@@ -144,25 +136,20 @@ export class GuidanceComponent implements OnChanges, OnInit, AfterContentInit, A
    */
   private _reloadGuard = false;
 
+  private _cdr = inject(ChangeDetectorRef);
   private _destroyRef = inject(DestroyRef);
   private _injector = inject(Injector);
 
   ngOnInit(): void {
     this._setCharacterLimitIndicatorValues();
 
-    if (this.control) {
-      this._syncControlState();
-      this.control.events
-        .pipe(takeUntilDestroyed(this._destroyRef))
-        .subscribe(() => this._syncControlState());
-    }
+    this.control?.events
+      .pipe(takeUntilDestroyed(this._destroyRef))
+      .subscribe(() => this._cdr.markForCheck());
 
-    if (this.formGroup) {
-      this._syncFormGroupState();
-      this.formGroup.events
-        .pipe(takeUntilDestroyed(this._destroyRef))
-        .subscribe(() => this._syncFormGroupState());
-    }
+    this.formGroup?.events
+      .pipe(takeUntilDestroyed(this._destroyRef))
+      .subscribe(() => this._cdr.markForCheck());
   }
 
   ngOnChanges(changes: FudisComponentChanges<GuidanceComponent>): void {
@@ -220,19 +207,6 @@ export class GuidanceComponent implements OnChanges, OnInit, AfterContentInit, A
         }
       }
     });
-  }
-
-  private _syncControlState(): void {
-    this._controlTouched.set(this.control.touched);
-    this._controlInvalid.set(this.control.invalid);
-    this._controlErrors.set(this.control.errors);
-    this._controlValueLength.set((this.control.value as string)?.length ?? 0);
-  }
-
-  private _syncFormGroupState(): void {
-    this._formGroupTouched.set(this.formGroup.touched);
-    this._formGroupInvalid.set(this.formGroup.invalid);
-    this._formGroupErrors.set(this.formGroup.errors);
   }
 
   private _setCharacterLimitIndicatorValues(): void {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.ts
@@ -1,6 +1,5 @@
 import {
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   DestroyRef,
   ElementRef,
@@ -15,7 +14,7 @@ import {
   Injector,
   WritableSignal,
 } from '@angular/core';
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormControl, FormGroup, ValidationErrors } from '@angular/forms';
 import { FudisTranslationService } from '../../../services/translation/translation.service';
 import { FudisIdService } from '../../../services/id/id.service';
 import { FudisInternalErrorSummaryService } from '../../../services/form/error-summary/internal-error-summary.service';
@@ -103,6 +102,15 @@ export class GuidanceComponent implements OnChanges, OnInit, AfterContentInit, A
    */
   protected _maxLengthText: WritableSignal<string> = signal<string>('');
 
+  protected _controlTouched: WritableSignal<boolean> = signal<boolean>(false);
+  protected _controlInvalid: WritableSignal<boolean> = signal<boolean>(false);
+  protected _controlErrors: WritableSignal<ValidationErrors | null> = signal<ValidationErrors | null>(null);
+  protected _controlValueLength: WritableSignal<number> = signal<number>(0);
+
+  protected _formGroupTouched: WritableSignal<boolean> = signal<boolean>(false);
+  protected _formGroupInvalid: WritableSignal<boolean> = signal<boolean>(false);
+  protected _formGroupErrors: WritableSignal<ValidationErrors | null> = signal<ValidationErrors | null>(null);
+
   /**
    * Number of characters left when screen reader is alerted about input max length
    */
@@ -136,20 +144,25 @@ export class GuidanceComponent implements OnChanges, OnInit, AfterContentInit, A
    */
   private _reloadGuard = false;
 
-  private _cdr = inject(ChangeDetectorRef);
   private _destroyRef = inject(DestroyRef);
   private _injector = inject(Injector);
 
   ngOnInit(): void {
     this._setCharacterLimitIndicatorValues();
 
-    this.control?.events
-      .pipe(takeUntilDestroyed(this._destroyRef))
-      .subscribe(() => this._cdr.markForCheck());
+    if (this.control) {
+      this._syncControlState();
+      this.control.events
+        .pipe(takeUntilDestroyed(this._destroyRef))
+        .subscribe(() => this._syncControlState());
+    }
 
-    this.formGroup?.events
-      .pipe(takeUntilDestroyed(this._destroyRef))
-      .subscribe(() => this._cdr.markForCheck());
+    if (this.formGroup) {
+      this._syncFormGroupState();
+      this.formGroup.events
+        .pipe(takeUntilDestroyed(this._destroyRef))
+        .subscribe(() => this._syncFormGroupState());
+    }
   }
 
   ngOnChanges(changes: FudisComponentChanges<GuidanceComponent>): void {
@@ -207,6 +220,19 @@ export class GuidanceComponent implements OnChanges, OnInit, AfterContentInit, A
         }
       }
     });
+  }
+
+  private _syncControlState(): void {
+    this._controlTouched.set(this.control.touched);
+    this._controlInvalid.set(this.control.invalid);
+    this._controlErrors.set(this.control.errors);
+    this._controlValueLength.set((this.control.value as string)?.length ?? 0);
+  }
+
+  private _syncFormGroupState(): void {
+    this._formGroupTouched.set(this.formGroup.touched);
+    this._formGroupInvalid.set(this.formGroup.invalid);
+    this._formGroupErrors.set(this.formGroup.errors);
   }
 
   private _setCharacterLimitIndicatorValues(): void {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.ts
@@ -1,5 +1,8 @@
 import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
+  DestroyRef,
   ElementRef,
   Input,
   OnChanges,
@@ -10,24 +13,25 @@ import {
   signal,
   AfterViewInit,
   Injector,
+  WritableSignal,
 } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { FudisTranslationService } from '../../../services/translation/translation.service';
 import { FudisIdService } from '../../../services/id/id.service';
 import { FudisInternalErrorSummaryService } from '../../../services/form/error-summary/internal-error-summary.service';
-import { toObservable } from '@angular/core/rxjs-interop';
-import { BehaviorSubject } from 'rxjs';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FudisComponentChanges } from '../../../types/miscellaneous';
 import { FudisErrorSummaryNewError } from '../../../types/errorSummary';
 import { IconComponent } from '../../icon/icon.component';
 import { ValidatorErrorMessageComponent } from '../error-message/validator-error-message/validator-error-message.component';
-import { AsyncPipe, KeyValuePipe } from '@angular/common';
+import { KeyValuePipe } from '@angular/common';
 
 @Component({
   selector: 'fudis-guidance',
   templateUrl: './guidance.component.html',
   styleUrls: ['./guidance.component.scss'],
-  imports: [IconComponent, ValidatorErrorMessageComponent, AsyncPipe, KeyValuePipe],
+  imports: [IconComponent, ValidatorErrorMessageComponent, KeyValuePipe],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GuidanceComponent implements OnChanges, OnInit, AfterContentInit, AfterViewInit {
   constructor(
@@ -39,7 +43,7 @@ export class GuidanceComponent implements OnChanges, OnInit, AfterContentInit, A
     this._id = _idService.getNewId('guidance');
 
     effect(() => {
-      this._maxLengthText.next(_translationService.getTranslations()().TEXTINPUT.MAX_LENGTH);
+      this._maxLengthText.set(_translationService.getTranslations()().TEXTINPUT.MAX_LENGTH);
     });
   }
 
@@ -97,7 +101,7 @@ export class GuidanceComponent implements OnChanges, OnInit, AfterContentInit, A
    * Assistive text of max character count for screen readers. E. g. "5/20 characters used" where
    * "characters used" is "maxLengthText".
    */
-  protected _maxLengthText = new BehaviorSubject<string>('');
+  protected _maxLengthText: WritableSignal<string> = signal<string>('');
 
   /**
    * Number of characters left when screen reader is alerted about input max length
@@ -120,22 +124,32 @@ export class GuidanceComponent implements OnChanges, OnInit, AfterContentInit, A
    */
   protected _lazyLoadedErrors: string[] = [];
 
-  protected _parentFormId = signal<string | null>(null);
+  protected _parentFormId: WritableSignal<string | null> = signal<string | null>(null);
 
   /**
    * Used prevent checks in HTML DOM before content has been loaded
    */
-  protected _afterViewInitDone = signal<boolean>(false);
+  protected _afterViewInitDone: WritableSignal<boolean> = signal<boolean>(false);
 
   /**
    * To prevent Error Summary reloading after lazy load check
    */
   private _reloadGuard = false;
 
+  private _cdr = inject(ChangeDetectorRef);
+  private _destroyRef = inject(DestroyRef);
   private _injector = inject(Injector);
 
   ngOnInit(): void {
     this._setCharacterLimitIndicatorValues();
+
+    this.control?.events
+      .pipe(takeUntilDestroyed(this._destroyRef))
+      .subscribe(() => this._cdr.markForCheck());
+
+    this.formGroup?.events
+      .pipe(takeUntilDestroyed(this._destroyRef))
+      .subscribe(() => this._cdr.markForCheck());
   }
 
   ngOnChanges(changes: FudisComponentChanges<GuidanceComponent>): void {

--- a/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/lib/components/form/guidance/guidance.component.ts
@@ -142,19 +142,23 @@ export class GuidanceComponent implements OnChanges, OnInit, AfterContentInit, A
 
   ngOnInit(): void {
     this._setCharacterLimitIndicatorValues();
-
-    this.control?.events
-      .pipe(takeUntilDestroyed(this._destroyRef))
-      .subscribe(() => this._cdr.markForCheck());
-
-    this.formGroup?.events
-      .pipe(takeUntilDestroyed(this._destroyRef))
-      .subscribe(() => this._cdr.markForCheck());
   }
 
   ngOnChanges(changes: FudisComponentChanges<GuidanceComponent>): void {
     if (changes.maxLength?.currentValue !== changes.maxLength?.previousValue) {
       this._setCharacterLimitIndicatorValues();
+    }
+
+    if (changes.control) {
+      this.control?.events
+        .pipe(takeUntilDestroyed(this._destroyRef))
+        .subscribe(() => this._cdr.markForCheck());
+    }
+
+    if (changes.formGroup) {
+      this.formGroup?.events
+        .pipe(takeUntilDestroyed(this._destroyRef))
+        .subscribe(() => this._cdr.markForCheck());
     }
   }
 


### PR DESCRIPTION
DS-676

Change Guidance component to use onPush.

- Guidance receives a FormControl or FormGroup as an input but does not bind it to a form element, but instead reads their state directly in the template (e.g. control.touched, control.errors). Since Angular's OnPush doesnt automatically detect changes in these properties, ChangeDetectorRef.markForCheck() is called via subscriptions to control.events and formGroup.events. This ensures the template changes whenever the control or form group state changes.

- _maxLengthText is converted from a BehaviorSubject to a signal, removing the need for AsyncPipe.
  
### Developer's checklist
- [ ] I wrote necessary unit tests
- [ ] I updated Storybook stories and documentation to reflect the latest changes
- [ ] I included visual regression tests for new UI design
- [ ] I tested my implementation with different browsers
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
- [ ] Together with the reviewer I can confirm that the implementation supports the following screenreader and browser combinations (NVDA + Firefox, VoiceOver + Chrome)
