### PR TITLE
[Chore]: Update recommended extenions

### DIFF
--- a/settings/.vscode/extensions.json
+++ b/settings/.vscode/extensions.json
@@ -8,12 +8,7 @@
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "stylelint.vscode-stylelint",
-    "formulahendry.auto-rename-tag",
-    "naumovs.color-highlight",
-    "unifiedjs.vscode-mdx",
-    "xyc.vscode-mdx-preview",
-    "nhoizey.gremlins",
     "deque-systems.vscode-axe-linter",
-    "tobermory.es6-string-html"
+    "unifiedjs.vscode-mdx"
   ]
 }


### PR DESCRIPTION
DS-662

Same extension removals as in Core PR: https://github.com/funidata/fudis-core/pull/191

- Went through our recommended extensions in VSCode
- Removed not-so-vital and unnecessary recommendations
- These extension recommendations should be treated as carefully as library dependencies

Removed extensions and some explanations:
- `formulahendry.auto-rename-tag`
  - Could improve devEx when used but not vital for workflow.
- `naumovs.color-highlight`
  - We use mainly color variables and only few files contain hex, rgba or hsl values. Does not give much, not important extension.
- `xyc.vscode-mdx-preview`
  - This was handy, but apparently the whole extension is broken and preview gives an error. There is an issue opened over two years ago. Not working, nor crucial part of the workflow.
- `nhoizey.gremlins`
  - Old as an oak, could be risky. We can rely mostly on just VSCode rendering and Prettier to handle unwanted chars.
- `tobermory.es6-string-html`
  - Not even sure what this is for, maybe some inline comment blocks. Seems unnecessary.
  
### Developer's checklist
- [ ] I wrote necessary unit tests
- [ ] I updated Storybook stories and documentation to reflect the latest changes
- [ ] I included visual regression tests for new UI design
- [ ] I tested my implementation with different browsers
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
- [ ] Together with the reviewer I can confirm that the implementation supports the following screenreader and browser combinations (NVDA + Firefox, VoiceOver + Chrome)
