### PR TITLE
[GithubActions]: Update aws-actions

### DIFF
--- a/.github/workflows/delete_branch_docs.yaml
+++ b/.github/workflows/delete_branch_docs.yaml
@@ -11,7 +11,7 @@ jobs:
       deployments: write
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/publish_docs_from_pr.yaml
+++ b/.github/workflows/publish_docs_from_pr.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
DS-662

- Updated `aws-actions/configure-aws-credentials` from `v4` to `v6`
  - `v6` is running on Node.js 24 which will be forced by default starting from June 16th, 2026.
- There is still one more action running on Node.js 20 which is `bobheadxi/deployments` but unfortunately it has yet been updated. There is open issue and PR about it in their repository.
  - This action is responsible for the branch deployment on each opened PR
  - I assume it is not crucial for our workflow so I didn't look up for alternatives yet. Could be worth to check if the same functionality can be implemented in a more "native" way, without third party action.
  
### Developer's checklist
- [ ] I wrote necessary unit tests
- [ ] I updated Storybook stories and documentation to reflect the latest changes
- [ ] I included visual regression tests for new UI design
- [ ] I tested my implementation with different browsers
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
- [ ] Together with the reviewer I can confirm that the implementation supports the following screenreader and browser combinations (NVDA + Firefox, VoiceOver + Chrome)
