### PR TITLE
[Chore]: Add moldoc to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the Fudis repo. They will be requested for review 
 # when someone opens a pull request.
-*     @RiinaKuu @MayaMarjut @mfaarni @krisrelax @emilyhernandez
+*     @RiinaKuu @MayaMarjut @mfaarni @krisrelax @emilyhernandez @moldoc


### PR DESCRIPTION
DS-681 --> https://funidata.atlassian.net/browse/DS-689

- Added **moldoc** temporarily to CODEOWNERS for the summer period
- They have also been added to _Collaborators and teams_ as admin
  - I didn't have permissions to modify the **fudis** team, so had to add separately
  
### Developer's checklist
- [ ] I wrote necessary unit tests
- [ ] I updated Storybook stories and documentation to reflect the latest changes
- [ ] I included visual regression tests for new UI design
- [ ] I tested my implementation with different browsers
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
- [ ] Together with the reviewer I can confirm that the implementation supports the following screenreader and browser combinations (NVDA + Firefox, VoiceOver + Chrome)
