### PR TITLE
[Scripts]: Remove --with-deps from tests' postinstall

### DIFF
--- a/ngx-fudis/projects/documentation/development/GettingStarted.mdx
+++ b/ngx-fudis/projects/documentation/development/GettingStarted.mdx
@@ -47,11 +47,19 @@ To install project dependencies, in the **root** directory run:
 npm ci
 ```
 
-**Note!** This does not install Playwright locally. If your OS is supported by Playwright and want to run Playwright with their UI tool run:
+**Note!** This does not install Playwright locally. If your OS is supported by Playwright and you want to run Playwright with their UI tool run:
 
 ```
 cd test && npm ci && cd ..
 ```
+
+**Linux users:** Before running the above command, install Playwright's system-level browser dependencies once with:
+
+```
+sudo npx playwright install-deps
+```
+
+Without this, you might get cryptic errors about missing browser dependencies. This is a one-time setup step. It is not needed on macOS or Windows.
 
 ## Development
 

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
   "description": "Visual regression tests for Fudis",
   "scripts": {
     "start": "npx playwright test --ui",
-    "postinstall": "npx playwright install --with-deps"
+    "postinstall": "npx playwright install"
   },
   "keywords": [],
   "author": "Funidata Ltd",


### PR DESCRIPTION
DS-681

The postinstall script for tests folder included `--with-deps`, which is used to install Playwright's browser libraries. This is a Linux specific command, as MacOS handles the dependencies differently. When running Linux, this caused the npm install command to prompt the user for their password for sudo, but the npm loading spinner obstructed the input field which made the install get stuck. 

To my knowledge, the required dependencies are usually already installed. To be sure that even first timers have them, I included a command to install the deps manually in the Getting Started-section of the docs.

  
### Developer's checklist
- [ ] I wrote necessary unit tests
- [ ] I updated Storybook stories and documentation to reflect the latest changes
- [ ] I included visual regression tests for new UI design
- [ ] I tested my implementation with different browsers
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
- [ ] Together with the reviewer I can confirm that the implementation supports the following screenreader and browser combinations (NVDA + Firefox, VoiceOver + Chrome)
