### PR TITLE
[chore]: Add MDX type helper for Typescipt

### DIFF
--- a/ngx-fudis/projects/ngx-fudis/src/mdx.d.ts
+++ b/ngx-fudis/projects/ngx-fudis/src/mdx.d.ts
@@ -1,0 +1,6 @@
+declare module '*.mdx' {
+  import type { ComponentType } from 'react';
+
+  const MDXContent: ComponentType<Record<string, unknown>>;
+  export default MDXContent;
+}


### PR DESCRIPTION
DS-695

All `*.stories.ts` files which were importing `.mdx` files had errors because Typescript didn't know how to type MDX files.

- Added `mdx.d.ts` under `/src`
- Not sure why `.storybook/tsconfig.json` types declaration was not enough even though it has mdx: "`types": ["node", "mdx"],`
- There is also mdx type declaration in `index.d.ts` coming from `@types/mdx` but for some (unknown) reason it was not visible for Typescript.
- Could be that the library `tsconfig.lib.json` types declaration `"types": ["node"]` is overwriting everything else, maybe.


### Developer's checklist

- [ ] I wrote necessary unit tests
- [ ] I updated Storybook stories and documentation to reflect the latest changes
- [ ] I included visual regression tests for new UI design
- [ ] I tested my implementation with different browsers
- [ ] I checked accessibility according to [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
- [ ] Together with the reviewer I can confirm that the implementation supports the following screenreader and browser combinations (NVDA + Firefox, VoiceOver + Chrome)
